### PR TITLE
feat(emitter): support differing accessor types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4320,7 +4320,8 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
     /**
      * Contains information about the current URL.
      */
-    location: Location;
+    get location(): Location;
+    set location(href: string | Location);
     onfullscreenchange: ((this: Document, ev: Event) => any) | null;
     onfullscreenerror: ((this: Document, ev: Event) => any) | null;
     onpointerlockchange: ((this: Document, ev: Event) => any) | null;
@@ -16958,7 +16959,8 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
     readonly innerHeight: number;
     readonly innerWidth: number;
     readonly length: number;
-    location: Location;
+    get location(): Location;
+    set location(href: string | Location);
     /**
      * Returns true if the location bar is visible; otherwise, returns false.
      */

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "prettier": "^2.2.1",
         "print-diff": "^1.0.0",
         "styleless-innertext": "^1.1.2",
-        "typescript": "^4.2.4",
+        "typescript": "^4.3.0-dev.20210327",
         "webidl2": "^23.13.1"
       }
     },
@@ -2816,9 +2816,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.0-dev.20210413",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.0-dev.20210413.tgz",
+      "integrity": "sha512-g4I8In27fKNvXS0STh3CXS4PvP0FYQ8Z1E0PqEuf20bNPRGJCm5+cEb4Yvd+udcqLTBVqpT8J/VCqaIoUXc3Tw==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5122,9 +5122,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.3.0-dev.20210413",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.0-dev.20210413.tgz",
+      "integrity": "sha512-g4I8In27fKNvXS0STh3CXS4PvP0FYQ8Z1E0PqEuf20bNPRGJCm5+cEb4Yvd+udcqLTBVqpT8J/VCqaIoUXc3Tw==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prettier": "^2.2.1",
     "print-diff": "^1.0.0",
     "styleless-innertext": "^1.1.2",
-    "typescript": "^4.2.4",
+    "typescript": "^4.3.0-dev.20210327",
     "webidl2": "^23.13.1"
   },
   "files": [

--- a/src/build/types.d.ts
+++ b/src/build/types.d.ts
@@ -31,7 +31,7 @@ export interface Property extends Typed {
   eventHandler?: string;
   readonly?: boolean;
   replaceable?: string;
-  "put-forwards"?: string;
+  putForwards?: string;
   stringifier?: boolean;
   tags?: string;
   "property-descriptor-not-enumerable"?: string;

--- a/src/build/widlprocess.ts
+++ b/src/build/widlprocess.ts
@@ -362,6 +362,7 @@ function convertAttribute(
     exposed:
       getExtAttrConcatenated(attribute.extAttrs, "Exposed") ||
       inheritedExposure,
+    putForwards: getExtAttr(attribute.extAttrs, "PutForwards")[0],
   };
 }
 

--- a/unittests/files/differingaccessors.ts
+++ b/unittests/files/differingaccessors.ts
@@ -1,0 +1,2 @@
+document.location.href.padStart(3);
+document.location = "abc";


### PR DESCRIPTION
Closes #87 

This works but should wait for the next typescript release to keep the npm package usable.