### PR TITLE
Remove the readonly attribute on all prototype

### DIFF
--- a/baselines/audioworklet.generated.d.ts
+++ b/baselines/audioworklet.generated.d.ts
@@ -119,7 +119,7 @@ interface AudioWorkletGlobalScope extends WorkletGlobalScope {
 }
 
 declare var AudioWorkletGlobalScope: {
-    readonly prototype: AudioWorkletGlobalScope;
+    prototype: AudioWorkletGlobalScope;
     new(): AudioWorkletGlobalScope;
 };
 
@@ -128,7 +128,7 @@ interface AudioWorkletProcessor {
 }
 
 declare var AudioWorkletProcessor: {
-    readonly prototype: AudioWorkletProcessor;
+    prototype: AudioWorkletProcessor;
     new(): AudioWorkletProcessor;
 };
 
@@ -139,7 +139,7 @@ interface ByteLengthQueuingStrategy extends QueuingStrategy<ArrayBufferView> {
 }
 
 declare var ByteLengthQueuingStrategy: {
-    readonly prototype: ByteLengthQueuingStrategy;
+    prototype: ByteLengthQueuingStrategy;
     new(init: QueuingStrategyInit): ByteLengthQueuingStrategy;
 };
 
@@ -150,7 +150,7 @@ interface CountQueuingStrategy extends QueuingStrategy {
 }
 
 declare var CountQueuingStrategy: {
-    readonly prototype: CountQueuingStrategy;
+    prototype: CountQueuingStrategy;
     new(init: QueuingStrategyInit): CountQueuingStrategy;
 };
 
@@ -226,7 +226,7 @@ interface Event {
 }
 
 declare var Event: {
-    readonly prototype: Event;
+    prototype: Event;
     new(type: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
@@ -263,7 +263,7 @@ interface EventTarget {
 }
 
 declare var EventTarget: {
-    readonly prototype: EventTarget;
+    prototype: EventTarget;
     new(): EventTarget;
 };
 
@@ -294,7 +294,7 @@ interface MessageEvent<T = any> extends Event {
 }
 
 declare var MessageEvent: {
-    readonly prototype: MessageEvent;
+    prototype: MessageEvent;
     new<T>(type: string, eventInitDict?: MessageEventInit<T>): MessageEvent<T>;
 };
 
@@ -329,7 +329,7 @@ interface MessagePort extends EventTarget {
 }
 
 declare var MessagePort: {
-    readonly prototype: MessagePort;
+    prototype: MessagePort;
     new(): MessagePort;
 };
 
@@ -345,7 +345,7 @@ interface ReadableStream<R = any> {
 }
 
 declare var ReadableStream: {
-    readonly prototype: ReadableStream;
+    prototype: ReadableStream;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 
@@ -357,7 +357,7 @@ interface ReadableStreamDefaultController<R = any> {
 }
 
 declare var ReadableStreamDefaultController: {
-    readonly prototype: ReadableStreamDefaultController;
+    prototype: ReadableStreamDefaultController;
     new(): ReadableStreamDefaultController;
 };
 
@@ -367,7 +367,7 @@ interface ReadableStreamDefaultReader<R = any> extends ReadableStreamGenericRead
 }
 
 declare var ReadableStreamDefaultReader: {
-    readonly prototype: ReadableStreamDefaultReader;
+    prototype: ReadableStreamDefaultReader;
     new<R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>;
 };
 
@@ -382,7 +382,7 @@ interface TransformStream<I = any, O = any> {
 }
 
 declare var TransformStream: {
-    readonly prototype: TransformStream;
+    prototype: TransformStream;
     new<I = any, O = any>(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>): TransformStream<I, O>;
 };
 
@@ -394,7 +394,7 @@ interface TransformStreamDefaultController<O = any> {
 }
 
 declare var TransformStreamDefaultController: {
-    readonly prototype: TransformStreamDefaultController;
+    prototype: TransformStreamDefaultController;
     new(): TransformStreamDefaultController;
 };
 
@@ -402,7 +402,7 @@ interface WorkletGlobalScope {
 }
 
 declare var WorkletGlobalScope: {
-    readonly prototype: WorkletGlobalScope;
+    prototype: WorkletGlobalScope;
     new(): WorkletGlobalScope;
 };
 
@@ -415,7 +415,7 @@ interface WritableStream<W = any> {
 }
 
 declare var WritableStream: {
-    readonly prototype: WritableStream;
+    prototype: WritableStream;
     new<W = any>(underlyingSink?: UnderlyingSink<W>, strategy?: QueuingStrategy<W>): WritableStream<W>;
 };
 
@@ -425,7 +425,7 @@ interface WritableStreamDefaultController {
 }
 
 declare var WritableStreamDefaultController: {
-    readonly prototype: WritableStreamDefaultController;
+    prototype: WritableStreamDefaultController;
     new(): WritableStreamDefaultController;
 };
 
@@ -441,7 +441,7 @@ interface WritableStreamDefaultWriter<W = any> {
 }
 
 declare var WritableStreamDefaultWriter: {
-    readonly prototype: WritableStreamDefaultWriter;
+    prototype: WritableStreamDefaultWriter;
     new<W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>;
 };
 
@@ -475,7 +475,7 @@ declare namespace WebAssembly {
     }
 
     var CompileError: {
-        readonly prototype: CompileError;
+        prototype: CompileError;
         new(): CompileError;
     };
 
@@ -485,7 +485,7 @@ declare namespace WebAssembly {
     }
 
     var Global: {
-        readonly prototype: Global;
+        prototype: Global;
         new(descriptor: GlobalDescriptor, v?: any): Global;
     };
 
@@ -494,7 +494,7 @@ declare namespace WebAssembly {
     }
 
     var Instance: {
-        readonly prototype: Instance;
+        prototype: Instance;
         new(module: Module, importObject?: Imports): Instance;
     };
 
@@ -502,7 +502,7 @@ declare namespace WebAssembly {
     }
 
     var LinkError: {
-        readonly prototype: LinkError;
+        prototype: LinkError;
         new(): LinkError;
     };
 
@@ -512,7 +512,7 @@ declare namespace WebAssembly {
     }
 
     var Memory: {
-        readonly prototype: Memory;
+        prototype: Memory;
         new(descriptor: MemoryDescriptor): Memory;
     };
 
@@ -520,7 +520,7 @@ declare namespace WebAssembly {
     }
 
     var Module: {
-        readonly prototype: Module;
+        prototype: Module;
         new(bytes: BufferSource): Module;
         customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
         exports(moduleObject: Module): ModuleExportDescriptor[];
@@ -531,7 +531,7 @@ declare namespace WebAssembly {
     }
 
     var RuntimeError: {
-        readonly prototype: RuntimeError;
+        prototype: RuntimeError;
         new(): RuntimeError;
     };
 
@@ -543,7 +543,7 @@ declare namespace WebAssembly {
     }
 
     var Table: {
-        readonly prototype: Table;
+        prototype: Table;
         new(descriptor: TableDescriptor, value?: any): Table;
     };
 

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1891,7 +1891,7 @@ interface AbortController {
 }
 
 declare var AbortController: {
-    readonly prototype: AbortController;
+    prototype: AbortController;
     new(): AbortController;
 };
 
@@ -1913,7 +1913,7 @@ interface AbortSignal extends EventTarget {
 }
 
 declare var AbortSignal: {
-    readonly prototype: AbortSignal;
+    prototype: AbortSignal;
     new(): AbortSignal;
 };
 
@@ -1941,7 +1941,7 @@ interface AbstractRange {
 }
 
 declare var AbstractRange: {
-    readonly prototype: AbstractRange;
+    prototype: AbstractRange;
     new(): AbstractRange;
 };
 
@@ -1971,7 +1971,7 @@ interface AnalyserNode extends AudioNode {
 }
 
 declare var AnalyserNode: {
-    readonly prototype: AnalyserNode;
+    prototype: AnalyserNode;
     new(context: BaseAudioContext, options?: AnalyserOptions): AnalyserNode;
 };
 
@@ -2016,7 +2016,7 @@ interface Animation extends EventTarget {
 }
 
 declare var Animation: {
-    readonly prototype: Animation;
+    prototype: Animation;
     new(effect?: AnimationEffect | null, timeline?: AnimationTimeline | null): Animation;
 };
 
@@ -2027,7 +2027,7 @@ interface AnimationEffect {
 }
 
 declare var AnimationEffect: {
-    readonly prototype: AnimationEffect;
+    prototype: AnimationEffect;
     new(): AnimationEffect;
 };
 
@@ -2039,7 +2039,7 @@ interface AnimationEvent extends Event {
 }
 
 declare var AnimationEvent: {
-    readonly prototype: AnimationEvent;
+    prototype: AnimationEvent;
     new(type: string, animationEventInitDict?: AnimationEventInit): AnimationEvent;
 };
 
@@ -2054,7 +2054,7 @@ interface AnimationPlaybackEvent extends Event {
 }
 
 declare var AnimationPlaybackEvent: {
-    readonly prototype: AnimationPlaybackEvent;
+    prototype: AnimationPlaybackEvent;
     new(type: string, eventInitDict?: AnimationPlaybackEventInit): AnimationPlaybackEvent;
 };
 
@@ -2063,7 +2063,7 @@ interface AnimationTimeline {
 }
 
 declare var AnimationTimeline: {
-    readonly prototype: AnimationTimeline;
+    prototype: AnimationTimeline;
     new(): AnimationTimeline;
 };
 
@@ -2080,7 +2080,7 @@ interface Attr extends Node {
 }
 
 declare var Attr: {
-    readonly prototype: Attr;
+    prototype: Attr;
     new(): Attr;
 };
 
@@ -2096,7 +2096,7 @@ interface AudioBuffer {
 }
 
 declare var AudioBuffer: {
-    readonly prototype: AudioBuffer;
+    prototype: AudioBuffer;
     new(options: AudioBufferOptions): AudioBuffer;
 };
 
@@ -2116,7 +2116,7 @@ interface AudioBufferSourceNode extends AudioScheduledSourceNode {
 }
 
 declare var AudioBufferSourceNode: {
-    readonly prototype: AudioBufferSourceNode;
+    prototype: AudioBufferSourceNode;
     new(context: BaseAudioContext, options?: AudioBufferSourceOptions): AudioBufferSourceNode;
 };
 
@@ -2137,7 +2137,7 @@ interface AudioContext extends BaseAudioContext {
 }
 
 declare var AudioContext: {
-    readonly prototype: AudioContext;
+    prototype: AudioContext;
     new(contextOptions?: AudioContextOptions): AudioContext;
 };
 
@@ -2147,7 +2147,7 @@ interface AudioDestinationNode extends AudioNode {
 }
 
 declare var AudioDestinationNode: {
-    readonly prototype: AudioDestinationNode;
+    prototype: AudioDestinationNode;
     new(): AudioDestinationNode;
 };
 
@@ -2169,7 +2169,7 @@ interface AudioListener {
 }
 
 declare var AudioListener: {
-    readonly prototype: AudioListener;
+    prototype: AudioListener;
     new(): AudioListener;
 };
 
@@ -2193,7 +2193,7 @@ interface AudioNode extends EventTarget {
 }
 
 declare var AudioNode: {
-    readonly prototype: AudioNode;
+    prototype: AudioNode;
     new(): AudioNode;
 };
 
@@ -2214,7 +2214,7 @@ interface AudioParam {
 }
 
 declare var AudioParam: {
-    readonly prototype: AudioParam;
+    prototype: AudioParam;
     new(): AudioParam;
 };
 
@@ -2223,7 +2223,7 @@ interface AudioParamMap {
 }
 
 declare var AudioParamMap: {
-    readonly prototype: AudioParamMap;
+    prototype: AudioParamMap;
     new(): AudioParamMap;
 };
 
@@ -2240,7 +2240,7 @@ interface AudioProcessingEvent extends Event {
 
 /** @deprecated */
 declare var AudioProcessingEvent: {
-    readonly prototype: AudioProcessingEvent;
+    prototype: AudioProcessingEvent;
     new(type: string, eventInitDict: AudioProcessingEventInit): AudioProcessingEvent;
 };
 
@@ -2259,7 +2259,7 @@ interface AudioScheduledSourceNode extends AudioNode {
 }
 
 declare var AudioScheduledSourceNode: {
-    readonly prototype: AudioScheduledSourceNode;
+    prototype: AudioScheduledSourceNode;
     new(): AudioScheduledSourceNode;
 };
 
@@ -2267,7 +2267,7 @@ interface AudioWorklet extends Worklet {
 }
 
 declare var AudioWorklet: {
-    readonly prototype: AudioWorklet;
+    prototype: AudioWorklet;
     new(): AudioWorklet;
 };
 
@@ -2286,7 +2286,7 @@ interface AudioWorkletNode extends AudioNode {
 }
 
 declare var AudioWorkletNode: {
-    readonly prototype: AudioWorkletNode;
+    prototype: AudioWorkletNode;
     new(context: BaseAudioContext, name: string, options?: AudioWorkletNodeOptions): AudioWorkletNode;
 };
 
@@ -2297,7 +2297,7 @@ interface AuthenticatorAssertionResponse extends AuthenticatorResponse {
 }
 
 declare var AuthenticatorAssertionResponse: {
-    readonly prototype: AuthenticatorAssertionResponse;
+    prototype: AuthenticatorAssertionResponse;
     new(): AuthenticatorAssertionResponse;
 };
 
@@ -2306,7 +2306,7 @@ interface AuthenticatorAttestationResponse extends AuthenticatorResponse {
 }
 
 declare var AuthenticatorAttestationResponse: {
-    readonly prototype: AuthenticatorAttestationResponse;
+    prototype: AuthenticatorAttestationResponse;
     new(): AuthenticatorAttestationResponse;
 };
 
@@ -2315,7 +2315,7 @@ interface AuthenticatorResponse {
 }
 
 declare var AuthenticatorResponse: {
-    readonly prototype: AuthenticatorResponse;
+    prototype: AuthenticatorResponse;
     new(): AuthenticatorResponse;
 };
 
@@ -2324,7 +2324,7 @@ interface BarProp {
 }
 
 declare var BarProp: {
-    readonly prototype: BarProp;
+    prototype: BarProp;
     new(): BarProp;
 };
 
@@ -2367,7 +2367,7 @@ interface BaseAudioContext extends EventTarget {
 }
 
 declare var BaseAudioContext: {
-    readonly prototype: BaseAudioContext;
+    prototype: BaseAudioContext;
     new(): BaseAudioContext;
 };
 
@@ -2377,7 +2377,7 @@ interface BeforeUnloadEvent extends Event {
 }
 
 declare var BeforeUnloadEvent: {
-    readonly prototype: BeforeUnloadEvent;
+    prototype: BeforeUnloadEvent;
     new(): BeforeUnloadEvent;
 };
 
@@ -2392,7 +2392,7 @@ interface BiquadFilterNode extends AudioNode {
 }
 
 declare var BiquadFilterNode: {
-    readonly prototype: BiquadFilterNode;
+    prototype: BiquadFilterNode;
     new(context: BaseAudioContext, options?: BiquadFilterOptions): BiquadFilterNode;
 };
 
@@ -2407,7 +2407,7 @@ interface Blob {
 }
 
 declare var Blob: {
-    readonly prototype: Blob;
+    prototype: Blob;
     new(blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
 };
 
@@ -2417,7 +2417,7 @@ interface BlobEvent extends Event {
 }
 
 declare var BlobEvent: {
-    readonly prototype: BlobEvent;
+    prototype: BlobEvent;
     new(type: string, eventInitDict: BlobEventInit): BlobEvent;
 };
 
@@ -2458,7 +2458,7 @@ interface BroadcastChannel extends EventTarget {
 }
 
 declare var BroadcastChannel: {
-    readonly prototype: BroadcastChannel;
+    prototype: BroadcastChannel;
     new(name: string): BroadcastChannel;
 };
 
@@ -2469,7 +2469,7 @@ interface ByteLengthQueuingStrategy extends QueuingStrategy<ArrayBufferView> {
 }
 
 declare var ByteLengthQueuingStrategy: {
-    readonly prototype: ByteLengthQueuingStrategy;
+    prototype: ByteLengthQueuingStrategy;
     new(init: QueuingStrategyInit): ByteLengthQueuingStrategy;
 };
 
@@ -2478,7 +2478,7 @@ interface CDATASection extends Text {
 }
 
 declare var CDATASection: {
-    readonly prototype: CDATASection;
+    prototype: CDATASection;
     new(): CDATASection;
 };
 
@@ -2491,7 +2491,7 @@ interface CSSAnimation extends Animation {
 }
 
 declare var CSSAnimation: {
-    readonly prototype: CSSAnimation;
+    prototype: CSSAnimation;
     new(): CSSAnimation;
 };
 
@@ -2501,7 +2501,7 @@ interface CSSConditionRule extends CSSGroupingRule {
 }
 
 declare var CSSConditionRule: {
-    readonly prototype: CSSConditionRule;
+    prototype: CSSConditionRule;
     new(): CSSConditionRule;
 };
 
@@ -2520,7 +2520,7 @@ interface CSSCounterStyleRule extends CSSRule {
 }
 
 declare var CSSCounterStyleRule: {
-    readonly prototype: CSSCounterStyleRule;
+    prototype: CSSCounterStyleRule;
     new(): CSSCounterStyleRule;
 };
 
@@ -2529,7 +2529,7 @@ interface CSSFontFaceRule extends CSSRule {
 }
 
 declare var CSSFontFaceRule: {
-    readonly prototype: CSSFontFaceRule;
+    prototype: CSSFontFaceRule;
     new(): CSSFontFaceRule;
 };
 
@@ -2541,7 +2541,7 @@ interface CSSGroupingRule extends CSSRule {
 }
 
 declare var CSSGroupingRule: {
-    readonly prototype: CSSGroupingRule;
+    prototype: CSSGroupingRule;
     new(): CSSGroupingRule;
 };
 
@@ -2552,7 +2552,7 @@ interface CSSImportRule extends CSSRule {
 }
 
 declare var CSSImportRule: {
-    readonly prototype: CSSImportRule;
+    prototype: CSSImportRule;
     new(): CSSImportRule;
 };
 
@@ -2563,7 +2563,7 @@ interface CSSKeyframeRule extends CSSRule {
 }
 
 declare var CSSKeyframeRule: {
-    readonly prototype: CSSKeyframeRule;
+    prototype: CSSKeyframeRule;
     new(): CSSKeyframeRule;
 };
 
@@ -2577,7 +2577,7 @@ interface CSSKeyframesRule extends CSSRule {
 }
 
 declare var CSSKeyframesRule: {
-    readonly prototype: CSSKeyframesRule;
+    prototype: CSSKeyframesRule;
     new(): CSSKeyframesRule;
 };
 
@@ -2587,7 +2587,7 @@ interface CSSMediaRule extends CSSConditionRule {
 }
 
 declare var CSSMediaRule: {
-    readonly prototype: CSSMediaRule;
+    prototype: CSSMediaRule;
     new(): CSSMediaRule;
 };
 
@@ -2598,7 +2598,7 @@ interface CSSNamespaceRule extends CSSRule {
 }
 
 declare var CSSNamespaceRule: {
-    readonly prototype: CSSNamespaceRule;
+    prototype: CSSNamespaceRule;
     new(): CSSNamespaceRule;
 };
 
@@ -2609,7 +2609,7 @@ interface CSSPageRule extends CSSGroupingRule {
 }
 
 declare var CSSPageRule: {
-    readonly prototype: CSSPageRule;
+    prototype: CSSPageRule;
     new(): CSSPageRule;
 };
 
@@ -2633,7 +2633,7 @@ interface CSSRule {
 }
 
 declare var CSSRule: {
-    readonly prototype: CSSRule;
+    prototype: CSSRule;
     new(): CSSRule;
     readonly CHARSET_RULE: number;
     readonly FONT_FACE_RULE: number;
@@ -2655,7 +2655,7 @@ interface CSSRuleList {
 }
 
 declare var CSSRuleList: {
-    readonly prototype: CSSRuleList;
+    prototype: CSSRuleList;
     new(): CSSRuleList;
 };
 
@@ -3188,7 +3188,7 @@ interface CSSStyleDeclaration {
 }
 
 declare var CSSStyleDeclaration: {
-    readonly prototype: CSSStyleDeclaration;
+    prototype: CSSStyleDeclaration;
     new(): CSSStyleDeclaration;
 };
 
@@ -3199,7 +3199,7 @@ interface CSSStyleRule extends CSSRule {
 }
 
 declare var CSSStyleRule: {
-    readonly prototype: CSSStyleRule;
+    prototype: CSSStyleRule;
     new(): CSSStyleRule;
 };
 
@@ -3218,7 +3218,7 @@ interface CSSStyleSheet extends StyleSheet {
 }
 
 declare var CSSStyleSheet: {
-    readonly prototype: CSSStyleSheet;
+    prototype: CSSStyleSheet;
     new(): CSSStyleSheet;
 };
 
@@ -3227,7 +3227,7 @@ interface CSSSupportsRule extends CSSConditionRule {
 }
 
 declare var CSSSupportsRule: {
-    readonly prototype: CSSSupportsRule;
+    prototype: CSSSupportsRule;
     new(): CSSSupportsRule;
 };
 
@@ -3240,7 +3240,7 @@ interface CSSTransition extends Animation {
 }
 
 declare var CSSTransition: {
-    readonly prototype: CSSTransition;
+    prototype: CSSTransition;
     new(): CSSTransition;
 };
 
@@ -3256,7 +3256,7 @@ interface Cache {
 }
 
 declare var Cache: {
-    readonly prototype: Cache;
+    prototype: Cache;
     new(): Cache;
 };
 
@@ -3270,7 +3270,7 @@ interface CacheStorage {
 }
 
 declare var CacheStorage: {
-    readonly prototype: CacheStorage;
+    prototype: CacheStorage;
     new(): CacheStorage;
 };
 
@@ -3322,7 +3322,7 @@ interface CanvasGradient {
 }
 
 declare var CanvasGradient: {
-    readonly prototype: CanvasGradient;
+    prototype: CanvasGradient;
     new(): CanvasGradient;
 };
 
@@ -3370,7 +3370,7 @@ interface CanvasPattern {
 }
 
 declare var CanvasPattern: {
-    readonly prototype: CanvasPattern;
+    prototype: CanvasPattern;
     new(): CanvasPattern;
 };
 
@@ -3386,7 +3386,7 @@ interface CanvasRenderingContext2D extends CanvasCompositing, CanvasDrawImage, C
 }
 
 declare var CanvasRenderingContext2D: {
-    readonly prototype: CanvasRenderingContext2D;
+    prototype: CanvasRenderingContext2D;
     new(): CanvasRenderingContext2D;
 };
 
@@ -3436,7 +3436,7 @@ interface ChannelMergerNode extends AudioNode {
 }
 
 declare var ChannelMergerNode: {
-    readonly prototype: ChannelMergerNode;
+    prototype: ChannelMergerNode;
     new(context: BaseAudioContext, options?: ChannelMergerOptions): ChannelMergerNode;
 };
 
@@ -3445,7 +3445,7 @@ interface ChannelSplitterNode extends AudioNode {
 }
 
 declare var ChannelSplitterNode: {
-    readonly prototype: ChannelSplitterNode;
+    prototype: ChannelSplitterNode;
     new(context: BaseAudioContext, options?: ChannelSplitterOptions): ChannelSplitterNode;
 };
 
@@ -3462,7 +3462,7 @@ interface CharacterData extends Node, ChildNode, NonDocumentTypeChildNode {
 }
 
 declare var CharacterData: {
-    readonly prototype: CharacterData;
+    prototype: CharacterData;
     new(): CharacterData;
 };
 
@@ -3499,7 +3499,7 @@ interface Clipboard extends EventTarget {
 }
 
 declare var Clipboard: {
-    readonly prototype: Clipboard;
+    prototype: Clipboard;
     new(): Clipboard;
 };
 
@@ -3509,7 +3509,7 @@ interface ClipboardEvent extends Event {
 }
 
 declare var ClipboardEvent: {
-    readonly prototype: ClipboardEvent;
+    prototype: ClipboardEvent;
     new(type: string, eventInitDict?: ClipboardEventInit): ClipboardEvent;
 };
 
@@ -3519,7 +3519,7 @@ interface ClipboardItem {
 }
 
 declare var ClipboardItem: {
-    readonly prototype: ClipboardItem;
+    prototype: ClipboardItem;
     new(items: Record<string, ClipboardItemData>, options?: ClipboardItemOptions): ClipboardItem;
 };
 
@@ -3540,7 +3540,7 @@ interface CloseEvent extends Event {
 }
 
 declare var CloseEvent: {
-    readonly prototype: CloseEvent;
+    prototype: CloseEvent;
     new(type: string, eventInitDict?: CloseEventInit): CloseEvent;
 };
 
@@ -3549,7 +3549,7 @@ interface Comment extends CharacterData {
 }
 
 declare var Comment: {
-    readonly prototype: Comment;
+    prototype: Comment;
     new(data?: string): Comment;
 };
 
@@ -3561,7 +3561,7 @@ interface CompositionEvent extends UIEvent {
 }
 
 declare var CompositionEvent: {
-    readonly prototype: CompositionEvent;
+    prototype: CompositionEvent;
     new(type: string, eventInitDict?: CompositionEventInit): CompositionEvent;
 };
 
@@ -3574,7 +3574,7 @@ interface ConstantSourceNode extends AudioScheduledSourceNode {
 }
 
 declare var ConstantSourceNode: {
-    readonly prototype: ConstantSourceNode;
+    prototype: ConstantSourceNode;
     new(context: BaseAudioContext, options?: ConstantSourceOptions): ConstantSourceNode;
 };
 
@@ -3585,7 +3585,7 @@ interface ConvolverNode extends AudioNode {
 }
 
 declare var ConvolverNode: {
-    readonly prototype: ConvolverNode;
+    prototype: ConvolverNode;
     new(context: BaseAudioContext, options?: ConvolverOptions): ConvolverNode;
 };
 
@@ -3596,7 +3596,7 @@ interface CountQueuingStrategy extends QueuingStrategy {
 }
 
 declare var CountQueuingStrategy: {
-    readonly prototype: CountQueuingStrategy;
+    prototype: CountQueuingStrategy;
     new(init: QueuingStrategyInit): CountQueuingStrategy;
 };
 
@@ -3606,7 +3606,7 @@ interface Credential {
 }
 
 declare var Credential: {
-    readonly prototype: Credential;
+    prototype: Credential;
     new(): Credential;
 };
 
@@ -3618,7 +3618,7 @@ interface CredentialsContainer {
 }
 
 declare var CredentialsContainer: {
-    readonly prototype: CredentialsContainer;
+    prototype: CredentialsContainer;
     new(): CredentialsContainer;
 };
 
@@ -3629,7 +3629,7 @@ interface Crypto {
 }
 
 declare var Crypto: {
-    readonly prototype: Crypto;
+    prototype: Crypto;
     new(): Crypto;
 };
 
@@ -3642,7 +3642,7 @@ interface CryptoKey {
 }
 
 declare var CryptoKey: {
-    readonly prototype: CryptoKey;
+    prototype: CryptoKey;
     new(): CryptoKey;
 };
 
@@ -3654,7 +3654,7 @@ interface CustomElementRegistry {
 }
 
 declare var CustomElementRegistry: {
-    readonly prototype: CustomElementRegistry;
+    prototype: CustomElementRegistry;
     new(): CustomElementRegistry;
 };
 
@@ -3668,7 +3668,7 @@ interface CustomEvent<T = any> extends Event {
 }
 
 declare var CustomEvent: {
-    readonly prototype: CustomEvent;
+    prototype: CustomEvent;
     new<T>(type: string, eventInitDict?: CustomEventInit<T>): CustomEvent<T>;
 };
 
@@ -3705,7 +3705,7 @@ interface DOMException {
 }
 
 declare var DOMException: {
-    readonly prototype: DOMException;
+    prototype: DOMException;
     new(message?: string, name?: string): DOMException;
     readonly ABORT_ERR: number;
     readonly DATA_CLONE_ERR: number;
@@ -3744,7 +3744,7 @@ interface DOMImplementation {
 }
 
 declare var DOMImplementation: {
-    readonly prototype: DOMImplementation;
+    prototype: DOMImplementation;
     new(): DOMImplementation;
 };
 
@@ -3764,7 +3764,7 @@ interface DOMMatrix extends DOMMatrixReadOnly {
 }
 
 declare var DOMMatrix: {
-    readonly prototype: DOMMatrix;
+    prototype: DOMMatrix;
     new(init?: string | number[]): DOMMatrix;
     fromFloat32Array(array32: Float32Array): DOMMatrix;
     fromFloat64Array(array64: Float64Array): DOMMatrix;
@@ -3824,7 +3824,7 @@ interface DOMMatrixReadOnly {
 }
 
 declare var DOMMatrixReadOnly: {
-    readonly prototype: DOMMatrixReadOnly;
+    prototype: DOMMatrixReadOnly;
     new(init?: string | number[]): DOMMatrixReadOnly;
     fromFloat32Array(array32: Float32Array): DOMMatrixReadOnly;
     fromFloat64Array(array64: Float64Array): DOMMatrixReadOnly;
@@ -3847,7 +3847,7 @@ interface DOMParser {
 }
 
 declare var DOMParser: {
-    readonly prototype: DOMParser;
+    prototype: DOMParser;
     new(): DOMParser;
 };
 
@@ -3855,7 +3855,7 @@ interface DOMPoint extends DOMPointReadOnly {
 }
 
 declare var DOMPoint: {
-    readonly prototype: DOMPoint;
+    prototype: DOMPoint;
     new(x?: number, y?: number, z?: number, w?: number): DOMPoint;
     fromPoint(other?: DOMPointInit): DOMPoint;
 };
@@ -3873,7 +3873,7 @@ interface DOMPointReadOnly {
 }
 
 declare var DOMPointReadOnly: {
-    readonly prototype: DOMPointReadOnly;
+    prototype: DOMPointReadOnly;
     new(x?: number, y?: number, z?: number, w?: number): DOMPointReadOnly;
     fromPoint(other?: DOMPointInit): DOMPointReadOnly;
 };
@@ -3888,7 +3888,7 @@ interface DOMQuad {
 }
 
 declare var DOMQuad: {
-    readonly prototype: DOMQuad;
+    prototype: DOMQuad;
     new(p1?: DOMPointInit, p2?: DOMPointInit, p3?: DOMPointInit, p4?: DOMPointInit): DOMQuad;
     fromQuad(other?: DOMQuadInit): DOMQuad;
     fromRect(other?: DOMRectInit): DOMQuad;
@@ -3898,7 +3898,7 @@ interface DOMRect extends DOMRectReadOnly {
 }
 
 declare var DOMRect: {
-    readonly prototype: DOMRect;
+    prototype: DOMRect;
     new(x?: number, y?: number, width?: number, height?: number): DOMRect;
     fromRect(other?: DOMRectInit): DOMRect;
 };
@@ -3913,7 +3913,7 @@ interface DOMRectList {
 }
 
 declare var DOMRectList: {
-    readonly prototype: DOMRectList;
+    prototype: DOMRectList;
     new(): DOMRectList;
 };
 
@@ -3930,7 +3930,7 @@ interface DOMRectReadOnly {
 }
 
 declare var DOMRectReadOnly: {
-    readonly prototype: DOMRectReadOnly;
+    prototype: DOMRectReadOnly;
     new(x?: number, y?: number, width?: number, height?: number): DOMRectReadOnly;
     fromRect(other?: DOMRectInit): DOMRectReadOnly;
 };
@@ -3953,7 +3953,7 @@ interface DOMStringList {
 }
 
 declare var DOMStringList: {
-    readonly prototype: DOMStringList;
+    prototype: DOMStringList;
     new(): DOMStringList;
 };
 
@@ -3963,7 +3963,7 @@ interface DOMStringMap {
 }
 
 declare var DOMStringMap: {
-    readonly prototype: DOMStringMap;
+    prototype: DOMStringMap;
     new(): DOMStringMap;
 };
 
@@ -4035,7 +4035,7 @@ interface DOMTokenList {
 }
 
 declare var DOMTokenList: {
-    readonly prototype: DOMTokenList;
+    prototype: DOMTokenList;
     new(): DOMTokenList;
 };
 
@@ -4088,7 +4088,7 @@ interface DataTransfer {
 }
 
 declare var DataTransfer: {
-    readonly prototype: DataTransfer;
+    prototype: DataTransfer;
     new(): DataTransfer;
 };
 
@@ -4114,7 +4114,7 @@ interface DataTransferItem {
 }
 
 declare var DataTransferItem: {
-    readonly prototype: DataTransferItem;
+    prototype: DataTransferItem;
     new(): DataTransferItem;
 };
 
@@ -4141,7 +4141,7 @@ interface DataTransferItemList {
 }
 
 declare var DataTransferItemList: {
-    readonly prototype: DataTransferItemList;
+    prototype: DataTransferItemList;
     new(): DataTransferItemList;
 };
 
@@ -4151,7 +4151,7 @@ interface DelayNode extends AudioNode {
 }
 
 declare var DelayNode: {
-    readonly prototype: DelayNode;
+    prototype: DelayNode;
     new(context: BaseAudioContext, options?: DelayOptions): DelayNode;
 };
 
@@ -4164,7 +4164,7 @@ interface DeviceMotionEvent extends Event {
 }
 
 declare var DeviceMotionEvent: {
-    readonly prototype: DeviceMotionEvent;
+    prototype: DeviceMotionEvent;
     new(type: string, eventInitDict?: DeviceMotionEventInit): DeviceMotionEvent;
 };
 
@@ -4189,7 +4189,7 @@ interface DeviceOrientationEvent extends Event {
 }
 
 declare var DeviceOrientationEvent: {
-    readonly prototype: DeviceOrientationEvent;
+    prototype: DeviceOrientationEvent;
     new(type: string, eventInitDict?: DeviceOrientationEventInit): DeviceOrientationEvent;
 };
 
@@ -4661,7 +4661,7 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
 }
 
 declare var Document: {
-    readonly prototype: Document;
+    prototype: Document;
     new(): Document;
 };
 
@@ -4686,7 +4686,7 @@ interface DocumentFragment extends Node, NonElementParentNode, ParentNode {
 }
 
 declare var DocumentFragment: {
-    readonly prototype: DocumentFragment;
+    prototype: DocumentFragment;
     new(): DocumentFragment;
 };
 
@@ -4716,7 +4716,7 @@ interface DocumentTimeline extends AnimationTimeline {
 }
 
 declare var DocumentTimeline: {
-    readonly prototype: DocumentTimeline;
+    prototype: DocumentTimeline;
     new(options?: DocumentTimelineOptions): DocumentTimeline;
 };
 
@@ -4729,7 +4729,7 @@ interface DocumentType extends Node, ChildNode {
 }
 
 declare var DocumentType: {
-    readonly prototype: DocumentType;
+    prototype: DocumentType;
     new(): DocumentType;
 };
 
@@ -4742,7 +4742,7 @@ interface DragEvent extends MouseEvent {
 }
 
 declare var DragEvent: {
-    readonly prototype: DragEvent;
+    prototype: DragEvent;
     new(type: string, eventInitDict?: DragEventInit): DragEvent;
 };
 
@@ -4757,7 +4757,7 @@ interface DynamicsCompressorNode extends AudioNode {
 }
 
 declare var DynamicsCompressorNode: {
-    readonly prototype: DynamicsCompressorNode;
+    prototype: DynamicsCompressorNode;
     new(context: BaseAudioContext, options?: DynamicsCompressorOptions): DynamicsCompressorNode;
 };
 
@@ -4969,7 +4969,7 @@ interface Element extends Node, ARIAMixin, Animatable, ChildNode, InnerHTML, Non
 }
 
 declare var Element: {
-    readonly prototype: Element;
+    prototype: Element;
     new(): Element;
 };
 
@@ -4994,7 +4994,7 @@ interface ErrorEvent extends Event {
 }
 
 declare var ErrorEvent: {
-    readonly prototype: ErrorEvent;
+    prototype: ErrorEvent;
     new(type: string, eventInitDict?: ErrorEventInit): ErrorEvent;
 };
 
@@ -5070,7 +5070,7 @@ interface Event {
 }
 
 declare var Event: {
-    readonly prototype: Event;
+    prototype: Event;
     new(type: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
@@ -5114,7 +5114,7 @@ interface EventSource extends EventTarget {
 }
 
 declare var EventSource: {
-    readonly prototype: EventSource;
+    prototype: EventSource;
     new(url: string | URL, eventSourceInitDict?: EventSourceInit): EventSource;
     readonly CLOSED: number;
     readonly CONNECTING: number;
@@ -5150,7 +5150,7 @@ interface EventTarget {
 }
 
 declare var EventTarget: {
-    readonly prototype: EventTarget;
+    prototype: EventTarget;
     new(): EventTarget;
 };
 
@@ -5164,7 +5164,7 @@ interface External {
 
 /** @deprecated */
 declare var External: {
-    readonly prototype: External;
+    prototype: External;
     new(): External;
 };
 
@@ -5176,7 +5176,7 @@ interface File extends Blob {
 }
 
 declare var File: {
-    readonly prototype: File;
+    prototype: File;
     new(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File;
 };
 
@@ -5188,7 +5188,7 @@ interface FileList {
 }
 
 declare var FileList: {
-    readonly prototype: FileList;
+    prototype: FileList;
     new(): FileList;
 };
 
@@ -5227,7 +5227,7 @@ interface FileReader extends EventTarget {
 }
 
 declare var FileReader: {
-    readonly prototype: FileReader;
+    prototype: FileReader;
     new(): FileReader;
     readonly DONE: number;
     readonly EMPTY: number;
@@ -5240,7 +5240,7 @@ interface FileSystem {
 }
 
 declare var FileSystem: {
-    readonly prototype: FileSystem;
+    prototype: FileSystem;
     new(): FileSystem;
 };
 
@@ -5251,7 +5251,7 @@ interface FileSystemDirectoryEntry extends FileSystemEntry {
 }
 
 declare var FileSystemDirectoryEntry: {
-    readonly prototype: FileSystemDirectoryEntry;
+    prototype: FileSystemDirectoryEntry;
     new(): FileSystemDirectoryEntry;
 };
 
@@ -5263,7 +5263,7 @@ interface FileSystemDirectoryReader {
 
 /** @deprecated */
 declare var FileSystemDirectoryReader: {
-    readonly prototype: FileSystemDirectoryReader;
+    prototype: FileSystemDirectoryReader;
     new(): FileSystemDirectoryReader;
 };
 
@@ -5277,7 +5277,7 @@ interface FileSystemEntry {
 }
 
 declare var FileSystemEntry: {
-    readonly prototype: FileSystemEntry;
+    prototype: FileSystemEntry;
     new(): FileSystemEntry;
 };
 
@@ -5286,7 +5286,7 @@ interface FileSystemFileEntry extends FileSystemEntry {
 }
 
 declare var FileSystemFileEntry: {
-    readonly prototype: FileSystemFileEntry;
+    prototype: FileSystemFileEntry;
     new(): FileSystemFileEntry;
 };
 
@@ -5296,7 +5296,7 @@ interface FocusEvent extends UIEvent {
 }
 
 declare var FocusEvent: {
-    readonly prototype: FocusEvent;
+    prototype: FocusEvent;
     new(type: string, eventInitDict?: FocusEventInit): FocusEvent;
 };
 
@@ -5319,7 +5319,7 @@ interface FontFace {
 }
 
 declare var FontFace: {
-    readonly prototype: FontFace;
+    prototype: FontFace;
     new(family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors): FontFace;
 };
 
@@ -5345,7 +5345,7 @@ interface FontFaceSet extends EventTarget {
 }
 
 declare var FontFaceSet: {
-    readonly prototype: FontFaceSet;
+    prototype: FontFaceSet;
     new(initialFaces: FontFace[]): FontFaceSet;
 };
 
@@ -5354,7 +5354,7 @@ interface FontFaceSetLoadEvent extends Event {
 }
 
 declare var FontFaceSetLoadEvent: {
-    readonly prototype: FontFaceSetLoadEvent;
+    prototype: FontFaceSetLoadEvent;
     new(type: string, eventInitDict?: FontFaceSetLoadEventInit): FontFaceSetLoadEvent;
 };
 
@@ -5374,7 +5374,7 @@ interface FormData {
 }
 
 declare var FormData: {
-    readonly prototype: FormData;
+    prototype: FormData;
     new(form?: HTMLFormElement): FormData;
 };
 
@@ -5386,7 +5386,7 @@ interface FormDataEvent extends Event {
 }
 
 declare var FormDataEvent: {
-    readonly prototype: FormDataEvent;
+    prototype: FormDataEvent;
     new(type: string, eventInitDict: FormDataEventInit): FormDataEvent;
 };
 
@@ -5396,7 +5396,7 @@ interface GainNode extends AudioNode {
 }
 
 declare var GainNode: {
-    readonly prototype: GainNode;
+    prototype: GainNode;
     new(context: BaseAudioContext, options?: GainOptions): GainNode;
 };
 
@@ -5413,7 +5413,7 @@ interface Gamepad {
 }
 
 declare var Gamepad: {
-    readonly prototype: Gamepad;
+    prototype: Gamepad;
     new(): Gamepad;
 };
 
@@ -5425,7 +5425,7 @@ interface GamepadButton {
 }
 
 declare var GamepadButton: {
-    readonly prototype: GamepadButton;
+    prototype: GamepadButton;
     new(): GamepadButton;
 };
 
@@ -5435,7 +5435,7 @@ interface GamepadEvent extends Event {
 }
 
 declare var GamepadEvent: {
-    readonly prototype: GamepadEvent;
+    prototype: GamepadEvent;
     new(type: string, eventInitDict: GamepadEventInit): GamepadEvent;
 };
 
@@ -5445,7 +5445,7 @@ interface GamepadHapticActuator {
 }
 
 declare var GamepadHapticActuator: {
-    readonly prototype: GamepadHapticActuator;
+    prototype: GamepadHapticActuator;
     new(): GamepadHapticActuator;
 };
 
@@ -5462,7 +5462,7 @@ interface Geolocation {
 }
 
 declare var Geolocation: {
-    readonly prototype: Geolocation;
+    prototype: Geolocation;
     new(): Geolocation;
 };
 
@@ -5477,7 +5477,7 @@ interface GeolocationCoordinates {
 }
 
 declare var GeolocationCoordinates: {
-    readonly prototype: GeolocationCoordinates;
+    prototype: GeolocationCoordinates;
     new(): GeolocationCoordinates;
 };
 
@@ -5487,7 +5487,7 @@ interface GeolocationPosition {
 }
 
 declare var GeolocationPosition: {
-    readonly prototype: GeolocationPosition;
+    prototype: GeolocationPosition;
     new(): GeolocationPosition;
 };
 
@@ -5500,7 +5500,7 @@ interface GeolocationPositionError {
 }
 
 declare var GeolocationPositionError: {
-    readonly prototype: GeolocationPositionError;
+    prototype: GeolocationPositionError;
     new(): GeolocationPositionError;
     readonly PERMISSION_DENIED: number;
     readonly POSITION_UNAVAILABLE: number;
@@ -5900,7 +5900,7 @@ interface HTMLAllCollection {
 }
 
 declare var HTMLAllCollection: {
-    readonly prototype: HTMLAllCollection;
+    prototype: HTMLAllCollection;
     new(): HTMLAllCollection;
 };
 
@@ -5959,7 +5959,7 @@ interface HTMLAnchorElement extends HTMLElement, HTMLHyperlinkElementUtils {
 }
 
 declare var HTMLAnchorElement: {
-    readonly prototype: HTMLAnchorElement;
+    prototype: HTMLAnchorElement;
     new(): HTMLAnchorElement;
 };
 
@@ -5998,7 +5998,7 @@ interface HTMLAreaElement extends HTMLElement, HTMLHyperlinkElementUtils {
 }
 
 declare var HTMLAreaElement: {
-    readonly prototype: HTMLAreaElement;
+    prototype: HTMLAreaElement;
     new(): HTMLAreaElement;
 };
 
@@ -6011,7 +6011,7 @@ interface HTMLAudioElement extends HTMLMediaElement {
 }
 
 declare var HTMLAudioElement: {
-    readonly prototype: HTMLAudioElement;
+    prototype: HTMLAudioElement;
     new(): HTMLAudioElement;
 };
 
@@ -6029,7 +6029,7 @@ interface HTMLBRElement extends HTMLElement {
 }
 
 declare var HTMLBRElement: {
-    readonly prototype: HTMLBRElement;
+    prototype: HTMLBRElement;
     new(): HTMLBRElement;
 };
 
@@ -6050,7 +6050,7 @@ interface HTMLBaseElement extends HTMLElement {
 }
 
 declare var HTMLBaseElement: {
-    readonly prototype: HTMLBaseElement;
+    prototype: HTMLBaseElement;
     new(): HTMLBaseElement;
 };
 
@@ -6081,7 +6081,7 @@ interface HTMLBodyElement extends HTMLElement, WindowEventHandlers {
 }
 
 declare var HTMLBodyElement: {
-    readonly prototype: HTMLBodyElement;
+    prototype: HTMLBodyElement;
     new(): HTMLBodyElement;
 };
 
@@ -6154,7 +6154,7 @@ interface HTMLButtonElement extends HTMLElement {
 }
 
 declare var HTMLButtonElement: {
-    readonly prototype: HTMLButtonElement;
+    prototype: HTMLButtonElement;
     new(): HTMLButtonElement;
 };
 
@@ -6191,7 +6191,7 @@ interface HTMLCanvasElement extends HTMLElement {
 }
 
 declare var HTMLCanvasElement: {
-    readonly prototype: HTMLCanvasElement;
+    prototype: HTMLCanvasElement;
     new(): HTMLCanvasElement;
 };
 
@@ -6216,7 +6216,7 @@ interface HTMLCollection extends HTMLCollectionBase {
 }
 
 declare var HTMLCollection: {
-    readonly prototype: HTMLCollection;
+    prototype: HTMLCollection;
     new(): HTMLCollection;
 };
 
@@ -6237,7 +6237,7 @@ interface HTMLDListElement extends HTMLElement {
 }
 
 declare var HTMLDListElement: {
-    readonly prototype: HTMLDListElement;
+    prototype: HTMLDListElement;
     new(): HTMLDListElement;
 };
 
@@ -6251,7 +6251,7 @@ interface HTMLDataElement extends HTMLElement {
 }
 
 declare var HTMLDataElement: {
-    readonly prototype: HTMLDataElement;
+    prototype: HTMLDataElement;
     new(): HTMLDataElement;
 };
 
@@ -6268,7 +6268,7 @@ interface HTMLDataListElement extends HTMLElement {
 }
 
 declare var HTMLDataListElement: {
-    readonly prototype: HTMLDataListElement;
+    prototype: HTMLDataListElement;
     new(): HTMLDataListElement;
 };
 
@@ -6281,7 +6281,7 @@ interface HTMLDetailsElement extends HTMLElement {
 }
 
 declare var HTMLDetailsElement: {
-    readonly prototype: HTMLDetailsElement;
+    prototype: HTMLDetailsElement;
     new(): HTMLDetailsElement;
 };
 
@@ -6297,7 +6297,7 @@ interface HTMLDirectoryElement extends HTMLElement {
 
 /** @deprecated */
 declare var HTMLDirectoryElement: {
-    readonly prototype: HTMLDirectoryElement;
+    prototype: HTMLDirectoryElement;
     new(): HTMLDirectoryElement;
 };
 
@@ -6315,7 +6315,7 @@ interface HTMLDivElement extends HTMLElement {
 }
 
 declare var HTMLDivElement: {
-    readonly prototype: HTMLDivElement;
+    prototype: HTMLDivElement;
     new(): HTMLDivElement;
 };
 
@@ -6349,7 +6349,7 @@ interface HTMLElement extends Element, DocumentAndElementEventHandlers, ElementC
 }
 
 declare var HTMLElement: {
-    readonly prototype: HTMLElement;
+    prototype: HTMLElement;
     new(): HTMLElement;
 };
 
@@ -6383,7 +6383,7 @@ interface HTMLEmbedElement extends HTMLElement {
 }
 
 declare var HTMLEmbedElement: {
-    readonly prototype: HTMLEmbedElement;
+    prototype: HTMLEmbedElement;
     new(): HTMLEmbedElement;
 };
 
@@ -6432,7 +6432,7 @@ interface HTMLFieldSetElement extends HTMLElement {
 }
 
 declare var HTMLFieldSetElement: {
-    readonly prototype: HTMLFieldSetElement;
+    prototype: HTMLFieldSetElement;
     new(): HTMLFieldSetElement;
 };
 
@@ -6456,7 +6456,7 @@ interface HTMLFontElement extends HTMLElement {
 
 /** @deprecated */
 declare var HTMLFontElement: {
-    readonly prototype: HTMLFontElement;
+    prototype: HTMLFontElement;
     new(): HTMLFontElement;
 };
 
@@ -6471,7 +6471,7 @@ interface HTMLFormControlsCollection extends HTMLCollectionBase {
 }
 
 declare var HTMLFormControlsCollection: {
-    readonly prototype: HTMLFormControlsCollection;
+    prototype: HTMLFormControlsCollection;
     new(): HTMLFormControlsCollection;
 };
 
@@ -6544,7 +6544,7 @@ interface HTMLFormElement extends HTMLElement {
 }
 
 declare var HTMLFormElement: {
-    readonly prototype: HTMLFormElement;
+    prototype: HTMLFormElement;
     new(): HTMLFormElement;
 };
 
@@ -6608,7 +6608,7 @@ interface HTMLFrameElement extends HTMLElement {
 
 /** @deprecated */
 declare var HTMLFrameElement: {
-    readonly prototype: HTMLFrameElement;
+    prototype: HTMLFrameElement;
     new(): HTMLFrameElement;
 };
 
@@ -6636,7 +6636,7 @@ interface HTMLFrameSetElement extends HTMLElement, WindowEventHandlers {
 
 /** @deprecated */
 declare var HTMLFrameSetElement: {
-    readonly prototype: HTMLFrameSetElement;
+    prototype: HTMLFrameSetElement;
     new(): HTMLFrameSetElement;
 };
 
@@ -6668,7 +6668,7 @@ interface HTMLHRElement extends HTMLElement {
 }
 
 declare var HTMLHRElement: {
-    readonly prototype: HTMLHRElement;
+    prototype: HTMLHRElement;
     new(): HTMLHRElement;
 };
 
@@ -6681,7 +6681,7 @@ interface HTMLHeadElement extends HTMLElement {
 }
 
 declare var HTMLHeadElement: {
-    readonly prototype: HTMLHeadElement;
+    prototype: HTMLHeadElement;
     new(): HTMLHeadElement;
 };
 
@@ -6699,7 +6699,7 @@ interface HTMLHeadingElement extends HTMLElement {
 }
 
 declare var HTMLHeadingElement: {
-    readonly prototype: HTMLHeadingElement;
+    prototype: HTMLHeadingElement;
     new(): HTMLHeadingElement;
 };
 
@@ -6717,7 +6717,7 @@ interface HTMLHtmlElement extends HTMLElement {
 }
 
 declare var HTMLHtmlElement: {
-    readonly prototype: HTMLHtmlElement;
+    prototype: HTMLHtmlElement;
     new(): HTMLHtmlElement;
 };
 
@@ -6861,7 +6861,7 @@ interface HTMLIFrameElement extends HTMLElement {
 }
 
 declare var HTMLIFrameElement: {
-    readonly prototype: HTMLIFrameElement;
+    prototype: HTMLIFrameElement;
     new(): HTMLIFrameElement;
 };
 
@@ -6952,7 +6952,7 @@ interface HTMLImageElement extends HTMLElement {
 }
 
 declare var HTMLImageElement: {
-    readonly prototype: HTMLImageElement;
+    prototype: HTMLImageElement;
     new(): HTMLImageElement;
 };
 
@@ -7162,7 +7162,7 @@ interface HTMLInputElement extends HTMLElement {
 }
 
 declare var HTMLInputElement: {
-    readonly prototype: HTMLInputElement;
+    prototype: HTMLInputElement;
     new(): HTMLInputElement;
 };
 
@@ -7181,7 +7181,7 @@ interface HTMLLIElement extends HTMLElement {
 }
 
 declare var HTMLLIElement: {
-    readonly prototype: HTMLLIElement;
+    prototype: HTMLLIElement;
     new(): HTMLLIElement;
 };
 
@@ -7206,7 +7206,7 @@ interface HTMLLabelElement extends HTMLElement {
 }
 
 declare var HTMLLabelElement: {
-    readonly prototype: HTMLLabelElement;
+    prototype: HTMLLabelElement;
     new(): HTMLLabelElement;
 };
 
@@ -7225,7 +7225,7 @@ interface HTMLLegendElement extends HTMLElement {
 }
 
 declare var HTMLLegendElement: {
-    readonly prototype: HTMLLegendElement;
+    prototype: HTMLLegendElement;
     new(): HTMLLegendElement;
 };
 
@@ -7282,7 +7282,7 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
 }
 
 declare var HTMLLinkElement: {
-    readonly prototype: HTMLLinkElement;
+    prototype: HTMLLinkElement;
     new(): HTMLLinkElement;
 };
 
@@ -7303,7 +7303,7 @@ interface HTMLMapElement extends HTMLElement {
 }
 
 declare var HTMLMapElement: {
-    readonly prototype: HTMLMapElement;
+    prototype: HTMLMapElement;
     new(): HTMLMapElement;
 };
 
@@ -7344,7 +7344,7 @@ interface HTMLMarqueeElement extends HTMLElement {
 
 /** @deprecated */
 declare var HTMLMarqueeElement: {
-    readonly prototype: HTMLMarqueeElement;
+    prototype: HTMLMarqueeElement;
     new(): HTMLMarqueeElement;
 };
 
@@ -7480,7 +7480,7 @@ interface HTMLMediaElement extends HTMLElement {
 }
 
 declare var HTMLMediaElement: {
-    readonly prototype: HTMLMediaElement;
+    prototype: HTMLMediaElement;
     new(): HTMLMediaElement;
     readonly HAVE_CURRENT_DATA: number;
     readonly HAVE_ENOUGH_DATA: number;
@@ -7503,7 +7503,7 @@ interface HTMLMenuElement extends HTMLElement {
 }
 
 declare var HTMLMenuElement: {
-    readonly prototype: HTMLMenuElement;
+    prototype: HTMLMenuElement;
     new(): HTMLMenuElement;
 };
 
@@ -7533,7 +7533,7 @@ interface HTMLMetaElement extends HTMLElement {
 }
 
 declare var HTMLMetaElement: {
-    readonly prototype: HTMLMetaElement;
+    prototype: HTMLMetaElement;
     new(): HTMLMetaElement;
 };
 
@@ -7553,7 +7553,7 @@ interface HTMLMeterElement extends HTMLElement {
 }
 
 declare var HTMLMeterElement: {
-    readonly prototype: HTMLMeterElement;
+    prototype: HTMLMeterElement;
     new(): HTMLMeterElement;
 };
 
@@ -7574,7 +7574,7 @@ interface HTMLModElement extends HTMLElement {
 }
 
 declare var HTMLModElement: {
-    readonly prototype: HTMLModElement;
+    prototype: HTMLModElement;
     new(): HTMLModElement;
 };
 
@@ -7595,7 +7595,7 @@ interface HTMLOListElement extends HTMLElement {
 }
 
 declare var HTMLOListElement: {
-    readonly prototype: HTMLOListElement;
+    prototype: HTMLOListElement;
     new(): HTMLOListElement;
 };
 
@@ -7699,7 +7699,7 @@ interface HTMLObjectElement extends HTMLElement {
 }
 
 declare var HTMLObjectElement: {
-    readonly prototype: HTMLObjectElement;
+    prototype: HTMLObjectElement;
     new(): HTMLObjectElement;
 };
 
@@ -7717,7 +7717,7 @@ interface HTMLOptGroupElement extends HTMLElement {
 }
 
 declare var HTMLOptGroupElement: {
-    readonly prototype: HTMLOptGroupElement;
+    prototype: HTMLOptGroupElement;
     new(): HTMLOptGroupElement;
 };
 
@@ -7759,7 +7759,7 @@ interface HTMLOptionElement extends HTMLElement {
 }
 
 declare var HTMLOptionElement: {
-    readonly prototype: HTMLOptionElement;
+    prototype: HTMLOptionElement;
     new(): HTMLOptionElement;
 };
 
@@ -7796,7 +7796,7 @@ interface HTMLOptionsCollection extends HTMLCollectionOf<HTMLOptionElement> {
 }
 
 declare var HTMLOptionsCollection: {
-    readonly prototype: HTMLOptionsCollection;
+    prototype: HTMLOptionsCollection;
     new(): HTMLOptionsCollection;
 };
 
@@ -7838,7 +7838,7 @@ interface HTMLOutputElement extends HTMLElement {
 }
 
 declare var HTMLOutputElement: {
-    readonly prototype: HTMLOutputElement;
+    prototype: HTMLOutputElement;
     new(): HTMLOutputElement;
 };
 
@@ -7856,7 +7856,7 @@ interface HTMLParagraphElement extends HTMLElement {
 }
 
 declare var HTMLParagraphElement: {
-    readonly prototype: HTMLParagraphElement;
+    prototype: HTMLParagraphElement;
     new(): HTMLParagraphElement;
 };
 
@@ -7887,7 +7887,7 @@ interface HTMLParamElement extends HTMLElement {
 }
 
 declare var HTMLParamElement: {
-    readonly prototype: HTMLParamElement;
+    prototype: HTMLParamElement;
     new(): HTMLParamElement;
 };
 
@@ -7900,7 +7900,7 @@ interface HTMLPictureElement extends HTMLElement {
 }
 
 declare var HTMLPictureElement: {
-    readonly prototype: HTMLPictureElement;
+    prototype: HTMLPictureElement;
     new(): HTMLPictureElement;
 };
 
@@ -7918,7 +7918,7 @@ interface HTMLPreElement extends HTMLElement {
 }
 
 declare var HTMLPreElement: {
-    readonly prototype: HTMLPreElement;
+    prototype: HTMLPreElement;
     new(): HTMLPreElement;
 };
 
@@ -7944,7 +7944,7 @@ interface HTMLProgressElement extends HTMLElement {
 }
 
 declare var HTMLProgressElement: {
-    readonly prototype: HTMLProgressElement;
+    prototype: HTMLProgressElement;
     new(): HTMLProgressElement;
 };
 
@@ -7961,7 +7961,7 @@ interface HTMLQuoteElement extends HTMLElement {
 }
 
 declare var HTMLQuoteElement: {
-    readonly prototype: HTMLQuoteElement;
+    prototype: HTMLQuoteElement;
     new(): HTMLQuoteElement;
 };
 
@@ -8010,7 +8010,7 @@ interface HTMLScriptElement extends HTMLElement {
 }
 
 declare var HTMLScriptElement: {
-    readonly prototype: HTMLScriptElement;
+    prototype: HTMLScriptElement;
     new(): HTMLScriptElement;
 };
 
@@ -8113,7 +8113,7 @@ interface HTMLSelectElement extends HTMLElement {
 }
 
 declare var HTMLSelectElement: {
-    readonly prototype: HTMLSelectElement;
+    prototype: HTMLSelectElement;
     new(): HTMLSelectElement;
 };
 
@@ -8128,7 +8128,7 @@ interface HTMLSlotElement extends HTMLElement {
 }
 
 declare var HTMLSlotElement: {
-    readonly prototype: HTMLSlotElement;
+    prototype: HTMLSlotElement;
     new(): HTMLSlotElement;
 };
 
@@ -8155,7 +8155,7 @@ interface HTMLSourceElement extends HTMLElement {
 }
 
 declare var HTMLSourceElement: {
-    readonly prototype: HTMLSourceElement;
+    prototype: HTMLSourceElement;
     new(): HTMLSourceElement;
 };
 
@@ -8168,7 +8168,7 @@ interface HTMLSpanElement extends HTMLElement {
 }
 
 declare var HTMLSpanElement: {
-    readonly prototype: HTMLSpanElement;
+    prototype: HTMLSpanElement;
     new(): HTMLSpanElement;
 };
 
@@ -8190,7 +8190,7 @@ interface HTMLStyleElement extends HTMLElement, LinkStyle {
 }
 
 declare var HTMLStyleElement: {
-    readonly prototype: HTMLStyleElement;
+    prototype: HTMLStyleElement;
     new(): HTMLStyleElement;
 };
 
@@ -8208,7 +8208,7 @@ interface HTMLTableCaptionElement extends HTMLElement {
 }
 
 declare var HTMLTableCaptionElement: {
-    readonly prototype: HTMLTableCaptionElement;
+    prototype: HTMLTableCaptionElement;
     new(): HTMLTableCaptionElement;
 };
 
@@ -8278,7 +8278,7 @@ interface HTMLTableCellElement extends HTMLElement {
 }
 
 declare var HTMLTableCellElement: {
-    readonly prototype: HTMLTableCellElement;
+    prototype: HTMLTableCellElement;
     new(): HTMLTableCellElement;
 };
 
@@ -8311,7 +8311,7 @@ interface HTMLTableColElement extends HTMLElement {
 }
 
 declare var HTMLTableColElement: {
-    readonly prototype: HTMLTableColElement;
+    prototype: HTMLTableColElement;
     new(): HTMLTableColElement;
 };
 
@@ -8424,7 +8424,7 @@ interface HTMLTableElement extends HTMLElement {
 }
 
 declare var HTMLTableElement: {
-    readonly prototype: HTMLTableElement;
+    prototype: HTMLTableElement;
     new(): HTMLTableElement;
 };
 
@@ -8472,7 +8472,7 @@ interface HTMLTableRowElement extends HTMLElement {
 }
 
 declare var HTMLTableRowElement: {
-    readonly prototype: HTMLTableRowElement;
+    prototype: HTMLTableRowElement;
     new(): HTMLTableRowElement;
 };
 
@@ -8510,7 +8510,7 @@ interface HTMLTableSectionElement extends HTMLElement {
 }
 
 declare var HTMLTableSectionElement: {
-    readonly prototype: HTMLTableSectionElement;
+    prototype: HTMLTableSectionElement;
     new(): HTMLTableSectionElement;
 };
 
@@ -8527,7 +8527,7 @@ interface HTMLTemplateElement extends HTMLElement {
 }
 
 declare var HTMLTemplateElement: {
-    readonly prototype: HTMLTemplateElement;
+    prototype: HTMLTemplateElement;
     new(): HTMLTemplateElement;
 };
 
@@ -8638,7 +8638,7 @@ interface HTMLTextAreaElement extends HTMLElement {
 }
 
 declare var HTMLTextAreaElement: {
-    readonly prototype: HTMLTextAreaElement;
+    prototype: HTMLTextAreaElement;
     new(): HTMLTextAreaElement;
 };
 
@@ -8652,7 +8652,7 @@ interface HTMLTimeElement extends HTMLElement {
 }
 
 declare var HTMLTimeElement: {
-    readonly prototype: HTMLTimeElement;
+    prototype: HTMLTimeElement;
     new(): HTMLTimeElement;
 };
 
@@ -8669,7 +8669,7 @@ interface HTMLTitleElement extends HTMLElement {
 }
 
 declare var HTMLTitleElement: {
-    readonly prototype: HTMLTitleElement;
+    prototype: HTMLTitleElement;
     new(): HTMLTitleElement;
 };
 
@@ -8696,7 +8696,7 @@ interface HTMLTrackElement extends HTMLElement {
 }
 
 declare var HTMLTrackElement: {
-    readonly prototype: HTMLTrackElement;
+    prototype: HTMLTrackElement;
     new(): HTMLTrackElement;
     readonly ERROR: number;
     readonly LOADED: number;
@@ -8717,7 +8717,7 @@ interface HTMLUListElement extends HTMLElement {
 }
 
 declare var HTMLUListElement: {
-    readonly prototype: HTMLUListElement;
+    prototype: HTMLUListElement;
     new(): HTMLUListElement;
 };
 
@@ -8730,7 +8730,7 @@ interface HTMLUnknownElement extends HTMLElement {
 }
 
 declare var HTMLUnknownElement: {
-    readonly prototype: HTMLUnknownElement;
+    prototype: HTMLUnknownElement;
     new(): HTMLUnknownElement;
 };
 
@@ -8777,7 +8777,7 @@ interface HTMLVideoElement extends HTMLMediaElement {
 }
 
 declare var HTMLVideoElement: {
-    readonly prototype: HTMLVideoElement;
+    prototype: HTMLVideoElement;
     new(): HTMLVideoElement;
 };
 
@@ -8794,7 +8794,7 @@ interface HashChangeEvent extends Event {
 }
 
 declare var HashChangeEvent: {
-    readonly prototype: HashChangeEvent;
+    prototype: HashChangeEvent;
     new(type: string, eventInitDict?: HashChangeEventInit): HashChangeEvent;
 };
 
@@ -8809,7 +8809,7 @@ interface Headers {
 }
 
 declare var Headers: {
-    readonly prototype: Headers;
+    prototype: Headers;
     new(init?: HeadersInit): Headers;
 };
 
@@ -8826,7 +8826,7 @@ interface History {
 }
 
 declare var History: {
-    readonly prototype: History;
+    prototype: History;
     new(): History;
 };
 
@@ -8878,7 +8878,7 @@ interface IDBCursor {
 }
 
 declare var IDBCursor: {
-    readonly prototype: IDBCursor;
+    prototype: IDBCursor;
     new(): IDBCursor;
 };
 
@@ -8891,7 +8891,7 @@ interface IDBCursorWithValue extends IDBCursor {
 }
 
 declare var IDBCursorWithValue: {
-    readonly prototype: IDBCursorWithValue;
+    prototype: IDBCursorWithValue;
     new(): IDBCursorWithValue;
 };
 
@@ -8947,7 +8947,7 @@ interface IDBDatabase extends EventTarget {
 }
 
 declare var IDBDatabase: {
-    readonly prototype: IDBDatabase;
+    prototype: IDBDatabase;
     new(): IDBDatabase;
 };
 
@@ -8971,7 +8971,7 @@ interface IDBFactory {
 }
 
 declare var IDBFactory: {
-    readonly prototype: IDBFactory;
+    prototype: IDBFactory;
     new(): IDBFactory;
 };
 
@@ -9033,7 +9033,7 @@ interface IDBIndex {
 }
 
 declare var IDBIndex: {
-    readonly prototype: IDBIndex;
+    prototype: IDBIndex;
     new(): IDBIndex;
 };
 
@@ -9062,7 +9062,7 @@ interface IDBKeyRange {
 }
 
 declare var IDBKeyRange: {
-    readonly prototype: IDBKeyRange;
+    prototype: IDBKeyRange;
     new(): IDBKeyRange;
     /**
      * Returns a new IDBKeyRange spanning from lower to upper. If lowerOpen is true, lower is not included in the range. If upperOpen is true, upper is not included in the range.
@@ -9194,7 +9194,7 @@ interface IDBObjectStore {
 }
 
 declare var IDBObjectStore: {
-    readonly prototype: IDBObjectStore;
+    prototype: IDBObjectStore;
     new(): IDBObjectStore;
 };
 
@@ -9214,7 +9214,7 @@ interface IDBOpenDBRequest extends IDBRequest<IDBDatabase> {
 }
 
 declare var IDBOpenDBRequest: {
-    readonly prototype: IDBOpenDBRequest;
+    prototype: IDBOpenDBRequest;
     new(): IDBOpenDBRequest;
 };
 
@@ -9254,7 +9254,7 @@ interface IDBRequest<T = any> extends EventTarget {
 }
 
 declare var IDBRequest: {
-    readonly prototype: IDBRequest;
+    prototype: IDBRequest;
     new(): IDBRequest;
 };
 
@@ -9300,7 +9300,7 @@ interface IDBTransaction extends EventTarget {
 }
 
 declare var IDBTransaction: {
-    readonly prototype: IDBTransaction;
+    prototype: IDBTransaction;
     new(): IDBTransaction;
 };
 
@@ -9311,7 +9311,7 @@ interface IDBVersionChangeEvent extends Event {
 }
 
 declare var IDBVersionChangeEvent: {
-    readonly prototype: IDBVersionChangeEvent;
+    prototype: IDBVersionChangeEvent;
     new(type: string, eventInitDict?: IDBVersionChangeEventInit): IDBVersionChangeEvent;
 };
 
@@ -9321,7 +9321,7 @@ interface IIRFilterNode extends AudioNode {
 }
 
 declare var IIRFilterNode: {
-    readonly prototype: IIRFilterNode;
+    prototype: IIRFilterNode;
     new(context: BaseAudioContext, options: IIRFilterOptions): IIRFilterNode;
 };
 
@@ -9331,7 +9331,7 @@ interface IdleDeadline {
 }
 
 declare var IdleDeadline: {
-    readonly prototype: IdleDeadline;
+    prototype: IdleDeadline;
     new(): IdleDeadline;
 };
 
@@ -9351,7 +9351,7 @@ interface ImageBitmap {
 }
 
 declare var ImageBitmap: {
-    readonly prototype: ImageBitmap;
+    prototype: ImageBitmap;
     new(): ImageBitmap;
 };
 
@@ -9367,7 +9367,7 @@ interface ImageBitmapRenderingContext {
 }
 
 declare var ImageBitmapRenderingContext: {
-    readonly prototype: ImageBitmapRenderingContext;
+    prototype: ImageBitmapRenderingContext;
     new(): ImageBitmapRenderingContext;
 };
 
@@ -9388,7 +9388,7 @@ interface ImageData {
 }
 
 declare var ImageData: {
-    readonly prototype: ImageData;
+    prototype: ImageData;
     new(sw: number, sh: number, settings?: ImageDataSettings): ImageData;
     new(data: Uint8ClampedArray, sw: number, sh?: number, settings?: ImageDataSettings): ImageData;
 };
@@ -9406,7 +9406,7 @@ interface InputEvent extends UIEvent {
 }
 
 declare var InputEvent: {
-    readonly prototype: InputEvent;
+    prototype: InputEvent;
     new(type: string, eventInitDict?: InputEventInit): InputEvent;
 };
 
@@ -9422,7 +9422,7 @@ interface IntersectionObserver {
 }
 
 declare var IntersectionObserver: {
-    readonly prototype: IntersectionObserver;
+    prototype: IntersectionObserver;
     new(callback: IntersectionObserverCallback, options?: IntersectionObserverInit): IntersectionObserver;
 };
 
@@ -9438,7 +9438,7 @@ interface IntersectionObserverEntry {
 }
 
 declare var IntersectionObserverEntry: {
-    readonly prototype: IntersectionObserverEntry;
+    prototype: IntersectionObserverEntry;
     new(intersectionObserverEntryInit: IntersectionObserverEntryInit): IntersectionObserverEntry;
 };
 
@@ -9469,7 +9469,7 @@ interface KeyboardEvent extends UIEvent {
 }
 
 declare var KeyboardEvent: {
-    readonly prototype: KeyboardEvent;
+    prototype: KeyboardEvent;
     new(type: string, eventInitDict?: KeyboardEventInit): KeyboardEvent;
     readonly DOM_KEY_LOCATION_LEFT: number;
     readonly DOM_KEY_LOCATION_NUMPAD: number;
@@ -9487,7 +9487,7 @@ interface KeyframeEffect extends AnimationEffect {
 }
 
 declare var KeyframeEffect: {
-    readonly prototype: KeyframeEffect;
+    prototype: KeyframeEffect;
     new(target: Element | null, keyframes: Keyframe[] | PropertyIndexedKeyframes | null, options?: number | KeyframeEffectOptions): KeyframeEffect;
     new(source: KeyframeEffect): KeyframeEffect;
 };
@@ -9570,7 +9570,7 @@ interface Location {
 }
 
 declare var Location: {
-    readonly prototype: Location;
+    prototype: Location;
     new(): Location;
 };
 
@@ -9585,7 +9585,7 @@ interface MathMLElement extends Element, DocumentAndElementEventHandlers, Elemen
 }
 
 declare var MathMLElement: {
-    readonly prototype: MathMLElement;
+    prototype: MathMLElement;
     new(): MathMLElement;
 };
 
@@ -9595,7 +9595,7 @@ interface MediaCapabilities {
 }
 
 declare var MediaCapabilities: {
-    readonly prototype: MediaCapabilities;
+    prototype: MediaCapabilities;
     new(): MediaCapabilities;
 };
 
@@ -9609,7 +9609,7 @@ interface MediaDeviceInfo {
 }
 
 declare var MediaDeviceInfo: {
-    readonly prototype: MediaDeviceInfo;
+    prototype: MediaDeviceInfo;
     new(): MediaDeviceInfo;
 };
 
@@ -9631,7 +9631,7 @@ interface MediaDevices extends EventTarget {
 }
 
 declare var MediaDevices: {
-    readonly prototype: MediaDevices;
+    prototype: MediaDevices;
     new(): MediaDevices;
 };
 
@@ -9641,7 +9641,7 @@ interface MediaElementAudioSourceNode extends AudioNode {
 }
 
 declare var MediaElementAudioSourceNode: {
-    readonly prototype: MediaElementAudioSourceNode;
+    prototype: MediaElementAudioSourceNode;
     new(context: AudioContext, options: MediaElementAudioSourceOptions): MediaElementAudioSourceNode;
 };
 
@@ -9651,7 +9651,7 @@ interface MediaEncryptedEvent extends Event {
 }
 
 declare var MediaEncryptedEvent: {
-    readonly prototype: MediaEncryptedEvent;
+    prototype: MediaEncryptedEvent;
     new(type: string, eventInitDict?: MediaEncryptedEventInit): MediaEncryptedEvent;
 };
 
@@ -9666,7 +9666,7 @@ interface MediaError {
 }
 
 declare var MediaError: {
-    readonly prototype: MediaError;
+    prototype: MediaError;
     new(): MediaError;
     readonly MEDIA_ERR_ABORTED: number;
     readonly MEDIA_ERR_DECODE: number;
@@ -9681,7 +9681,7 @@ interface MediaKeyMessageEvent extends Event {
 }
 
 declare var MediaKeyMessageEvent: {
-    readonly prototype: MediaKeyMessageEvent;
+    prototype: MediaKeyMessageEvent;
     new(type: string, eventInitDict: MediaKeyMessageEventInit): MediaKeyMessageEvent;
 };
 
@@ -9710,7 +9710,7 @@ interface MediaKeySession extends EventTarget {
 }
 
 declare var MediaKeySession: {
-    readonly prototype: MediaKeySession;
+    prototype: MediaKeySession;
     new(): MediaKeySession;
 };
 
@@ -9723,7 +9723,7 @@ interface MediaKeyStatusMap {
 }
 
 declare var MediaKeyStatusMap: {
-    readonly prototype: MediaKeyStatusMap;
+    prototype: MediaKeyStatusMap;
     new(): MediaKeyStatusMap;
 };
 
@@ -9735,7 +9735,7 @@ interface MediaKeySystemAccess {
 }
 
 declare var MediaKeySystemAccess: {
-    readonly prototype: MediaKeySystemAccess;
+    prototype: MediaKeySystemAccess;
     new(): MediaKeySystemAccess;
 };
 
@@ -9746,7 +9746,7 @@ interface MediaKeys {
 }
 
 declare var MediaKeys: {
-    readonly prototype: MediaKeys;
+    prototype: MediaKeys;
     new(): MediaKeys;
 };
 
@@ -9761,7 +9761,7 @@ interface MediaList {
 }
 
 declare var MediaList: {
-    readonly prototype: MediaList;
+    prototype: MediaList;
     new(): MediaList;
 };
 
@@ -9773,7 +9773,7 @@ interface MediaMetadata {
 }
 
 declare var MediaMetadata: {
-    readonly prototype: MediaMetadata;
+    prototype: MediaMetadata;
     new(init?: MediaMetadataInit): MediaMetadata;
 };
 
@@ -9797,7 +9797,7 @@ interface MediaQueryList extends EventTarget {
 }
 
 declare var MediaQueryList: {
-    readonly prototype: MediaQueryList;
+    prototype: MediaQueryList;
     new(): MediaQueryList;
 };
 
@@ -9807,7 +9807,7 @@ interface MediaQueryListEvent extends Event {
 }
 
 declare var MediaQueryListEvent: {
-    readonly prototype: MediaQueryListEvent;
+    prototype: MediaQueryListEvent;
     new(type: string, eventInitDict?: MediaQueryListEventInit): MediaQueryListEvent;
 };
 
@@ -9844,7 +9844,7 @@ interface MediaRecorder extends EventTarget {
 }
 
 declare var MediaRecorder: {
-    readonly prototype: MediaRecorder;
+    prototype: MediaRecorder;
     new(stream: MediaStream, options?: MediaRecorderOptions): MediaRecorder;
     isTypeSupported(type: string): boolean;
 };
@@ -9854,7 +9854,7 @@ interface MediaRecorderErrorEvent extends Event {
 }
 
 declare var MediaRecorderErrorEvent: {
-    readonly prototype: MediaRecorderErrorEvent;
+    prototype: MediaRecorderErrorEvent;
     new(type: string, eventInitDict: MediaRecorderErrorEventInit): MediaRecorderErrorEvent;
 };
 
@@ -9866,7 +9866,7 @@ interface MediaSession {
 }
 
 declare var MediaSession: {
-    readonly prototype: MediaSession;
+    prototype: MediaSession;
     new(): MediaSession;
 };
 
@@ -9897,7 +9897,7 @@ interface MediaSource extends EventTarget {
 }
 
 declare var MediaSource: {
-    readonly prototype: MediaSource;
+    prototype: MediaSource;
     new(): MediaSource;
     isTypeSupported(type: string): boolean;
 };
@@ -9927,7 +9927,7 @@ interface MediaStream extends EventTarget {
 }
 
 declare var MediaStream: {
-    readonly prototype: MediaStream;
+    prototype: MediaStream;
     new(): MediaStream;
     new(stream: MediaStream): MediaStream;
     new(tracks: MediaStreamTrack[]): MediaStream;
@@ -9938,7 +9938,7 @@ interface MediaStreamAudioDestinationNode extends AudioNode {
 }
 
 declare var MediaStreamAudioDestinationNode: {
-    readonly prototype: MediaStreamAudioDestinationNode;
+    prototype: MediaStreamAudioDestinationNode;
     new(context: AudioContext, options?: AudioNodeOptions): MediaStreamAudioDestinationNode;
 };
 
@@ -9948,7 +9948,7 @@ interface MediaStreamAudioSourceNode extends AudioNode {
 }
 
 declare var MediaStreamAudioSourceNode: {
-    readonly prototype: MediaStreamAudioSourceNode;
+    prototype: MediaStreamAudioSourceNode;
     new(context: AudioContext, options: MediaStreamAudioSourceOptions): MediaStreamAudioSourceNode;
 };
 
@@ -9983,7 +9983,7 @@ interface MediaStreamTrack extends EventTarget {
 }
 
 declare var MediaStreamTrack: {
-    readonly prototype: MediaStreamTrack;
+    prototype: MediaStreamTrack;
     new(): MediaStreamTrack;
 };
 
@@ -9993,7 +9993,7 @@ interface MediaStreamTrackEvent extends Event {
 }
 
 declare var MediaStreamTrackEvent: {
-    readonly prototype: MediaStreamTrackEvent;
+    prototype: MediaStreamTrackEvent;
     new(type: string, eventInitDict: MediaStreamTrackEventInit): MediaStreamTrackEvent;
 };
 
@@ -10010,7 +10010,7 @@ interface MessageChannel {
 }
 
 declare var MessageChannel: {
-    readonly prototype: MessageChannel;
+    prototype: MessageChannel;
     new(): MessageChannel;
 };
 
@@ -10041,7 +10041,7 @@ interface MessageEvent<T = any> extends Event {
 }
 
 declare var MessageEvent: {
-    readonly prototype: MessageEvent;
+    prototype: MessageEvent;
     new<T>(type: string, eventInitDict?: MessageEventInit<T>): MessageEvent<T>;
 };
 
@@ -10076,7 +10076,7 @@ interface MessagePort extends EventTarget {
 }
 
 declare var MessagePort: {
-    readonly prototype: MessagePort;
+    prototype: MessagePort;
     new(): MessagePort;
 };
 
@@ -10107,7 +10107,7 @@ interface MimeType {
 
 /** @deprecated */
 declare var MimeType: {
-    readonly prototype: MimeType;
+    prototype: MimeType;
     new(): MimeType;
 };
 
@@ -10125,7 +10125,7 @@ interface MimeTypeArray {
 
 /** @deprecated */
 declare var MimeTypeArray: {
-    readonly prototype: MimeTypeArray;
+    prototype: MimeTypeArray;
     new(): MimeTypeArray;
 };
 
@@ -10156,7 +10156,7 @@ interface MouseEvent extends UIEvent {
 }
 
 declare var MouseEvent: {
-    readonly prototype: MouseEvent;
+    prototype: MouseEvent;
     new(type: string, eventInitDict?: MouseEventInit): MouseEvent;
 };
 
@@ -10175,7 +10175,7 @@ interface MutationEvent extends Event {
 }
 
 declare var MutationEvent: {
-    readonly prototype: MutationEvent;
+    prototype: MutationEvent;
     new(): MutationEvent;
     readonly ADDITION: number;
     readonly MODIFICATION: number;
@@ -10201,7 +10201,7 @@ interface MutationObserver {
 }
 
 declare var MutationObserver: {
-    readonly prototype: MutationObserver;
+    prototype: MutationObserver;
     new(callback: MutationCallback): MutationObserver;
 };
 
@@ -10246,7 +10246,7 @@ interface MutationRecord {
 }
 
 declare var MutationRecord: {
-    readonly prototype: MutationRecord;
+    prototype: MutationRecord;
     new(): MutationRecord;
 };
 
@@ -10264,7 +10264,7 @@ interface NamedNodeMap {
 }
 
 declare var NamedNodeMap: {
-    readonly prototype: NamedNodeMap;
+    prototype: NamedNodeMap;
     new(): NamedNodeMap;
 };
 
@@ -10289,7 +10289,7 @@ interface Navigator extends NavigatorAutomationInformation, NavigatorConcurrentH
 }
 
 declare var Navigator: {
-    readonly prototype: Navigator;
+    prototype: Navigator;
     new(): Navigator;
 };
 
@@ -10360,7 +10360,7 @@ interface NetworkInformation extends EventTarget {
 }
 
 declare var NetworkInformation: {
-    readonly prototype: NetworkInformation;
+    prototype: NetworkInformation;
     new(): NetworkInformation;
 };
 
@@ -10512,7 +10512,7 @@ interface Node extends EventTarget {
 }
 
 declare var Node: {
-    readonly prototype: Node;
+    prototype: Node;
     new(): Node;
     readonly ATTRIBUTE_NODE: number;
     /**
@@ -10587,7 +10587,7 @@ interface NodeIterator {
 }
 
 declare var NodeIterator: {
-    readonly prototype: NodeIterator;
+    prototype: NodeIterator;
     new(): NodeIterator;
 };
 
@@ -10611,7 +10611,7 @@ interface NodeList {
 }
 
 declare var NodeList: {
-    readonly prototype: NodeList;
+    prototype: NodeList;
     new(): NodeList;
 };
 
@@ -10672,7 +10672,7 @@ interface Notification extends EventTarget {
 }
 
 declare var Notification: {
-    readonly prototype: Notification;
+    prototype: Notification;
     new(title: string, options?: NotificationOptions): Notification;
     readonly permission: NotificationPermission;
     requestPermission(deprecatedCallback?: NotificationPermissionCallback): Promise<NotificationPermission>;
@@ -10729,7 +10729,7 @@ interface OfflineAudioCompletionEvent extends Event {
 }
 
 declare var OfflineAudioCompletionEvent: {
-    readonly prototype: OfflineAudioCompletionEvent;
+    prototype: OfflineAudioCompletionEvent;
     new(type: string, eventInitDict: OfflineAudioCompletionEventInit): OfflineAudioCompletionEvent;
 };
 
@@ -10751,7 +10751,7 @@ interface OfflineAudioContext extends BaseAudioContext {
 }
 
 declare var OfflineAudioContext: {
-    readonly prototype: OfflineAudioContext;
+    prototype: OfflineAudioContext;
     new(contextOptions: OfflineAudioContextOptions): OfflineAudioContext;
     new(numberOfChannels: number, length: number, sampleRate: number): OfflineAudioContext;
 };
@@ -10769,7 +10769,7 @@ interface OscillatorNode extends AudioScheduledSourceNode {
 }
 
 declare var OscillatorNode: {
-    readonly prototype: OscillatorNode;
+    prototype: OscillatorNode;
     new(context: BaseAudioContext, options?: OscillatorOptions): OscillatorNode;
 };
 
@@ -10778,7 +10778,7 @@ interface OverconstrainedError extends Error {
 }
 
 declare var OverconstrainedError: {
-    readonly prototype: OverconstrainedError;
+    prototype: OverconstrainedError;
     new(constraint: string, message?: string): OverconstrainedError;
 };
 
@@ -10800,7 +10800,7 @@ interface PageTransitionEvent extends Event {
 }
 
 declare var PageTransitionEvent: {
-    readonly prototype: PageTransitionEvent;
+    prototype: PageTransitionEvent;
     new(type: string, eventInitDict?: PageTransitionEventInit): PageTransitionEvent;
 };
 
@@ -10827,7 +10827,7 @@ interface PannerNode extends AudioNode {
 }
 
 declare var PannerNode: {
-    readonly prototype: PannerNode;
+    prototype: PannerNode;
     new(context: BaseAudioContext, options?: PannerOptions): PannerNode;
 };
 
@@ -10886,7 +10886,7 @@ interface Path2D extends CanvasPath {
 }
 
 declare var Path2D: {
-    readonly prototype: Path2D;
+    prototype: Path2D;
     new(path?: Path2D | string): Path2D;
 };
 
@@ -10919,7 +10919,7 @@ interface PaymentAddress {
 
 /** @deprecated */
 declare var PaymentAddress: {
-    readonly prototype: PaymentAddress;
+    prototype: PaymentAddress;
     new(): PaymentAddress;
 };
 
@@ -10929,7 +10929,7 @@ interface PaymentMethodChangeEvent extends PaymentRequestUpdateEvent {
 }
 
 declare var PaymentMethodChangeEvent: {
-    readonly prototype: PaymentMethodChangeEvent;
+    prototype: PaymentMethodChangeEvent;
     new(type: string, eventInitDict?: PaymentMethodChangeEventInit): PaymentMethodChangeEvent;
 };
 
@@ -10951,7 +10951,7 @@ interface PaymentRequest extends EventTarget {
 }
 
 declare var PaymentRequest: {
-    readonly prototype: PaymentRequest;
+    prototype: PaymentRequest;
     new(methodData: PaymentMethodData[], details: PaymentDetailsInit): PaymentRequest;
 };
 
@@ -10961,7 +10961,7 @@ interface PaymentRequestUpdateEvent extends Event {
 }
 
 declare var PaymentRequestUpdateEvent: {
-    readonly prototype: PaymentRequestUpdateEvent;
+    prototype: PaymentRequestUpdateEvent;
     new(type: string, eventInitDict?: PaymentRequestUpdateEventInit): PaymentRequestUpdateEvent;
 };
 
@@ -10976,7 +10976,7 @@ interface PaymentResponse extends EventTarget {
 }
 
 declare var PaymentResponse: {
-    readonly prototype: PaymentResponse;
+    prototype: PaymentResponse;
     new(): PaymentResponse;
 };
 
@@ -11010,7 +11010,7 @@ interface Performance extends EventTarget {
 }
 
 declare var Performance: {
-    readonly prototype: Performance;
+    prototype: Performance;
     new(): Performance;
 };
 
@@ -11024,7 +11024,7 @@ interface PerformanceEntry {
 }
 
 declare var PerformanceEntry: {
-    readonly prototype: PerformanceEntry;
+    prototype: PerformanceEntry;
     new(): PerformanceEntry;
 };
 
@@ -11036,7 +11036,7 @@ interface PerformanceEventTiming extends PerformanceEntry {
 }
 
 declare var PerformanceEventTiming: {
-    readonly prototype: PerformanceEventTiming;
+    prototype: PerformanceEventTiming;
     new(): PerformanceEventTiming;
 };
 
@@ -11046,7 +11046,7 @@ interface PerformanceMark extends PerformanceEntry {
 }
 
 declare var PerformanceMark: {
-    readonly prototype: PerformanceMark;
+    prototype: PerformanceMark;
     new(markName: string, markOptions?: PerformanceMarkOptions): PerformanceMark;
 };
 
@@ -11056,7 +11056,7 @@ interface PerformanceMeasure extends PerformanceEntry {
 }
 
 declare var PerformanceMeasure: {
-    readonly prototype: PerformanceMeasure;
+    prototype: PerformanceMeasure;
     new(): PerformanceMeasure;
 };
 
@@ -11077,7 +11077,7 @@ interface PerformanceNavigation {
 
 /** @deprecated */
 declare var PerformanceNavigation: {
-    readonly prototype: PerformanceNavigation;
+    prototype: PerformanceNavigation;
     new(): PerformanceNavigation;
     readonly TYPE_BACK_FORWARD: number;
     readonly TYPE_NAVIGATE: number;
@@ -11101,7 +11101,7 @@ interface PerformanceNavigationTiming extends PerformanceResourceTiming {
 }
 
 declare var PerformanceNavigationTiming: {
-    readonly prototype: PerformanceNavigationTiming;
+    prototype: PerformanceNavigationTiming;
     new(): PerformanceNavigationTiming;
 };
 
@@ -11112,7 +11112,7 @@ interface PerformanceObserver {
 }
 
 declare var PerformanceObserver: {
-    readonly prototype: PerformanceObserver;
+    prototype: PerformanceObserver;
     new(callback: PerformanceObserverCallback): PerformanceObserver;
     readonly supportedEntryTypes: ReadonlyArray<string>;
 };
@@ -11124,7 +11124,7 @@ interface PerformanceObserverEntryList {
 }
 
 declare var PerformanceObserverEntryList: {
-    readonly prototype: PerformanceObserverEntryList;
+    prototype: PerformanceObserverEntryList;
     new(): PerformanceObserverEntryList;
 };
 
@@ -11132,7 +11132,7 @@ interface PerformancePaintTiming extends PerformanceEntry {
 }
 
 declare var PerformancePaintTiming: {
-    readonly prototype: PerformancePaintTiming;
+    prototype: PerformancePaintTiming;
     new(): PerformancePaintTiming;
 };
 
@@ -11160,7 +11160,7 @@ interface PerformanceResourceTiming extends PerformanceEntry {
 }
 
 declare var PerformanceResourceTiming: {
-    readonly prototype: PerformanceResourceTiming;
+    prototype: PerformanceResourceTiming;
     new(): PerformanceResourceTiming;
 };
 
@@ -11172,7 +11172,7 @@ interface PerformanceServerTiming {
 }
 
 declare var PerformanceServerTiming: {
-    readonly prototype: PerformanceServerTiming;
+    prototype: PerformanceServerTiming;
     new(): PerformanceServerTiming;
 };
 
@@ -11227,7 +11227,7 @@ interface PerformanceTiming {
 
 /** @deprecated */
 declare var PerformanceTiming: {
-    readonly prototype: PerformanceTiming;
+    prototype: PerformanceTiming;
     new(): PerformanceTiming;
 };
 
@@ -11236,7 +11236,7 @@ interface PeriodicWave {
 }
 
 declare var PeriodicWave: {
-    readonly prototype: PeriodicWave;
+    prototype: PeriodicWave;
     new(context: BaseAudioContext, options?: PeriodicWaveOptions): PeriodicWave;
 };
 
@@ -11254,7 +11254,7 @@ interface PermissionStatus extends EventTarget {
 }
 
 declare var PermissionStatus: {
-    readonly prototype: PermissionStatus;
+    prototype: PermissionStatus;
     new(): PermissionStatus;
 };
 
@@ -11263,7 +11263,7 @@ interface Permissions {
 }
 
 declare var Permissions: {
-    readonly prototype: Permissions;
+    prototype: Permissions;
     new(): Permissions;
 };
 
@@ -11282,7 +11282,7 @@ interface PictureInPictureWindow extends EventTarget {
 }
 
 declare var PictureInPictureWindow: {
-    readonly prototype: PictureInPictureWindow;
+    prototype: PictureInPictureWindow;
     new(): PictureInPictureWindow;
 };
 
@@ -11321,7 +11321,7 @@ interface Plugin {
 
 /** @deprecated */
 declare var Plugin: {
-    readonly prototype: Plugin;
+    prototype: Plugin;
     new(): Plugin;
 };
 
@@ -11341,7 +11341,7 @@ interface PluginArray {
 
 /** @deprecated */
 declare var PluginArray: {
-    readonly prototype: PluginArray;
+    prototype: PluginArray;
     new(): PluginArray;
 };
 
@@ -11361,7 +11361,7 @@ interface PointerEvent extends MouseEvent {
 }
 
 declare var PointerEvent: {
-    readonly prototype: PointerEvent;
+    prototype: PointerEvent;
     new(type: string, eventInitDict?: PointerEventInit): PointerEvent;
 };
 
@@ -11374,7 +11374,7 @@ interface PopStateEvent extends Event {
 }
 
 declare var PopStateEvent: {
-    readonly prototype: PopStateEvent;
+    prototype: PopStateEvent;
     new(type: string, eventInitDict?: PopStateEventInit): PopStateEvent;
 };
 
@@ -11385,7 +11385,7 @@ interface ProcessingInstruction extends CharacterData, LinkStyle {
 }
 
 declare var ProcessingInstruction: {
-    readonly prototype: ProcessingInstruction;
+    prototype: ProcessingInstruction;
     new(): ProcessingInstruction;
 };
 
@@ -11398,7 +11398,7 @@ interface ProgressEvent<T extends EventTarget = EventTarget> extends Event {
 }
 
 declare var ProgressEvent: {
-    readonly prototype: ProgressEvent;
+    prototype: ProgressEvent;
     new(type: string, eventInitDict?: ProgressEventInit): ProgressEvent;
 };
 
@@ -11408,7 +11408,7 @@ interface PromiseRejectionEvent extends Event {
 }
 
 declare var PromiseRejectionEvent: {
-    readonly prototype: PromiseRejectionEvent;
+    prototype: PromiseRejectionEvent;
     new(type: string, eventInitDict: PromiseRejectionEventInit): PromiseRejectionEvent;
 };
 
@@ -11419,7 +11419,7 @@ interface PublicKeyCredential extends Credential {
 }
 
 declare var PublicKeyCredential: {
-    readonly prototype: PublicKeyCredential;
+    prototype: PublicKeyCredential;
     new(): PublicKeyCredential;
     isUserVerifyingPlatformAuthenticatorAvailable(): Promise<boolean>;
 };
@@ -11432,7 +11432,7 @@ interface PushManager {
 }
 
 declare var PushManager: {
-    readonly prototype: PushManager;
+    prototype: PushManager;
     new(): PushManager;
     readonly supportedContentEncodings: ReadonlyArray<string>;
 };
@@ -11447,7 +11447,7 @@ interface PushSubscription {
 }
 
 declare var PushSubscription: {
-    readonly prototype: PushSubscription;
+    prototype: PushSubscription;
     new(): PushSubscription;
 };
 
@@ -11456,7 +11456,7 @@ interface PushSubscriptionOptions {
 }
 
 declare var PushSubscriptionOptions: {
-    readonly prototype: PushSubscriptionOptions;
+    prototype: PushSubscriptionOptions;
     new(): PushSubscriptionOptions;
 };
 
@@ -11466,7 +11466,7 @@ interface RTCCertificate {
 }
 
 declare var RTCCertificate: {
-    readonly prototype: RTCCertificate;
+    prototype: RTCCertificate;
     new(): RTCCertificate;
 };
 
@@ -11486,7 +11486,7 @@ interface RTCDTMFSender extends EventTarget {
 }
 
 declare var RTCDTMFSender: {
-    readonly prototype: RTCDTMFSender;
+    prototype: RTCDTMFSender;
     new(): RTCDTMFSender;
 };
 
@@ -11496,7 +11496,7 @@ interface RTCDTMFToneChangeEvent extends Event {
 }
 
 declare var RTCDTMFToneChangeEvent: {
-    readonly prototype: RTCDTMFToneChangeEvent;
+    prototype: RTCDTMFToneChangeEvent;
     new(type: string, eventInitDict?: RTCDTMFToneChangeEventInit): RTCDTMFToneChangeEvent;
 };
 
@@ -11537,7 +11537,7 @@ interface RTCDataChannel extends EventTarget {
 }
 
 declare var RTCDataChannel: {
-    readonly prototype: RTCDataChannel;
+    prototype: RTCDataChannel;
     new(): RTCDataChannel;
 };
 
@@ -11546,7 +11546,7 @@ interface RTCDataChannelEvent extends Event {
 }
 
 declare var RTCDataChannelEvent: {
-    readonly prototype: RTCDataChannelEvent;
+    prototype: RTCDataChannelEvent;
     new(type: string, eventInitDict: RTCDataChannelEventInit): RTCDataChannelEvent;
 };
 
@@ -11564,7 +11564,7 @@ interface RTCDtlsTransport extends EventTarget {
 }
 
 declare var RTCDtlsTransport: {
-    readonly prototype: RTCDtlsTransport;
+    prototype: RTCDtlsTransport;
     new(): RTCDtlsTransport;
 };
 
@@ -11588,7 +11588,7 @@ interface RTCIceCandidate {
 }
 
 declare var RTCIceCandidate: {
-    readonly prototype: RTCIceCandidate;
+    prototype: RTCIceCandidate;
     new(candidateInitDict?: RTCIceCandidateInit): RTCIceCandidate;
 };
 
@@ -11599,7 +11599,7 @@ interface RTCIceTransport extends EventTarget {
 }
 
 declare var RTCIceTransport: {
-    readonly prototype: RTCIceTransport;
+    prototype: RTCIceTransport;
     new(): RTCIceTransport;
 };
 
@@ -11669,7 +11669,7 @@ interface RTCPeerConnection extends EventTarget {
 }
 
 declare var RTCPeerConnection: {
-    readonly prototype: RTCPeerConnection;
+    prototype: RTCPeerConnection;
     new(configuration?: RTCConfiguration): RTCPeerConnection;
     generateCertificate(keygenAlgorithm: AlgorithmIdentifier): Promise<RTCCertificate>;
 };
@@ -11681,7 +11681,7 @@ interface RTCPeerConnectionIceErrorEvent extends Event {
 }
 
 declare var RTCPeerConnectionIceErrorEvent: {
-    readonly prototype: RTCPeerConnectionIceErrorEvent;
+    prototype: RTCPeerConnectionIceErrorEvent;
     new(type: string, eventInitDict: RTCPeerConnectionIceErrorEventInit): RTCPeerConnectionIceErrorEvent;
 };
 
@@ -11691,7 +11691,7 @@ interface RTCPeerConnectionIceEvent extends Event {
 }
 
 declare var RTCPeerConnectionIceEvent: {
-    readonly prototype: RTCPeerConnectionIceEvent;
+    prototype: RTCPeerConnectionIceEvent;
     new(type: string, eventInitDict?: RTCPeerConnectionIceEventInit): RTCPeerConnectionIceEvent;
 };
 
@@ -11706,7 +11706,7 @@ interface RTCRtpReceiver {
 }
 
 declare var RTCRtpReceiver: {
-    readonly prototype: RTCRtpReceiver;
+    prototype: RTCRtpReceiver;
     new(): RTCRtpReceiver;
     getCapabilities(kind: string): RTCRtpCapabilities | null;
 };
@@ -11724,7 +11724,7 @@ interface RTCRtpSender {
 }
 
 declare var RTCRtpSender: {
-    readonly prototype: RTCRtpSender;
+    prototype: RTCRtpSender;
     new(): RTCRtpSender;
     getCapabilities(kind: string): RTCRtpCapabilities | null;
 };
@@ -11739,7 +11739,7 @@ interface RTCRtpTransceiver {
 }
 
 declare var RTCRtpTransceiver: {
-    readonly prototype: RTCRtpTransceiver;
+    prototype: RTCRtpTransceiver;
     new(): RTCRtpTransceiver;
 };
 
@@ -11751,7 +11751,7 @@ interface RTCSessionDescription {
 }
 
 declare var RTCSessionDescription: {
-    readonly prototype: RTCSessionDescription;
+    prototype: RTCSessionDescription;
     new(descriptionInitDict: RTCSessionDescriptionInit): RTCSessionDescription;
 };
 
@@ -11760,7 +11760,7 @@ interface RTCStatsReport {
 }
 
 declare var RTCStatsReport: {
-    readonly prototype: RTCStatsReport;
+    prototype: RTCStatsReport;
     new(): RTCStatsReport;
 };
 
@@ -11772,7 +11772,7 @@ interface RTCTrackEvent extends Event {
 }
 
 declare var RTCTrackEvent: {
-    readonly prototype: RTCTrackEvent;
+    prototype: RTCTrackEvent;
     new(type: string, eventInitDict: RTCTrackEventInit): RTCTrackEvent;
 };
 
@@ -11781,7 +11781,7 @@ interface RadioNodeList extends NodeList {
 }
 
 declare var RadioNodeList: {
-    readonly prototype: RadioNodeList;
+    prototype: RadioNodeList;
     new(): RadioNodeList;
 };
 
@@ -11828,7 +11828,7 @@ interface Range extends AbstractRange {
 }
 
 declare var Range: {
-    readonly prototype: Range;
+    prototype: Range;
     new(): Range;
     readonly END_TO_END: number;
     readonly END_TO_START: number;
@@ -11849,7 +11849,7 @@ interface ReadableStream<R = any> {
 }
 
 declare var ReadableStream: {
-    readonly prototype: ReadableStream;
+    prototype: ReadableStream;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 
@@ -11861,7 +11861,7 @@ interface ReadableStreamDefaultController<R = any> {
 }
 
 declare var ReadableStreamDefaultController: {
-    readonly prototype: ReadableStreamDefaultController;
+    prototype: ReadableStreamDefaultController;
     new(): ReadableStreamDefaultController;
 };
 
@@ -11871,7 +11871,7 @@ interface ReadableStreamDefaultReader<R = any> extends ReadableStreamGenericRead
 }
 
 declare var ReadableStreamDefaultReader: {
-    readonly prototype: ReadableStreamDefaultReader;
+    prototype: ReadableStreamDefaultReader;
     new<R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>;
 };
 
@@ -11901,7 +11901,7 @@ interface RemotePlayback extends EventTarget {
 }
 
 declare var RemotePlayback: {
-    readonly prototype: RemotePlayback;
+    prototype: RemotePlayback;
     new(): RemotePlayback;
 };
 
@@ -11963,7 +11963,7 @@ interface Request extends Body {
 }
 
 declare var Request: {
-    readonly prototype: Request;
+    prototype: Request;
     new(input: RequestInfo, init?: RequestInit): Request;
 };
 
@@ -11974,7 +11974,7 @@ interface ResizeObserver {
 }
 
 declare var ResizeObserver: {
-    readonly prototype: ResizeObserver;
+    prototype: ResizeObserver;
     new(callback: ResizeObserverCallback): ResizeObserver;
 };
 
@@ -11986,7 +11986,7 @@ interface ResizeObserverEntry {
 }
 
 declare var ResizeObserverEntry: {
-    readonly prototype: ResizeObserverEntry;
+    prototype: ResizeObserverEntry;
     new(): ResizeObserverEntry;
 };
 
@@ -11996,7 +11996,7 @@ interface ResizeObserverSize {
 }
 
 declare var ResizeObserverSize: {
-    readonly prototype: ResizeObserverSize;
+    prototype: ResizeObserverSize;
     new(): ResizeObserverSize;
 };
 
@@ -12013,7 +12013,7 @@ interface Response extends Body {
 }
 
 declare var Response: {
-    readonly prototype: Response;
+    prototype: Response;
     new(body?: BodyInit | null, init?: ResponseInit): Response;
     error(): Response;
     redirect(url: string | URL, status?: number): Response;
@@ -12031,7 +12031,7 @@ interface SVGAElement extends SVGGraphicsElement, SVGURIReference {
 }
 
 declare var SVGAElement: {
-    readonly prototype: SVGAElement;
+    prototype: SVGAElement;
     new(): SVGAElement;
 };
 
@@ -12051,7 +12051,7 @@ interface SVGAngle {
 }
 
 declare var SVGAngle: {
-    readonly prototype: SVGAngle;
+    prototype: SVGAngle;
     new(): SVGAngle;
     readonly SVG_ANGLETYPE_DEG: number;
     readonly SVG_ANGLETYPE_GRAD: number;
@@ -12068,7 +12068,7 @@ interface SVGAnimateElement extends SVGAnimationElement {
 }
 
 declare var SVGAnimateElement: {
-    readonly prototype: SVGAnimateElement;
+    prototype: SVGAnimateElement;
     new(): SVGAnimateElement;
 };
 
@@ -12080,7 +12080,7 @@ interface SVGAnimateMotionElement extends SVGAnimationElement {
 }
 
 declare var SVGAnimateMotionElement: {
-    readonly prototype: SVGAnimateMotionElement;
+    prototype: SVGAnimateMotionElement;
     new(): SVGAnimateMotionElement;
 };
 
@@ -12092,7 +12092,7 @@ interface SVGAnimateTransformElement extends SVGAnimationElement {
 }
 
 declare var SVGAnimateTransformElement: {
-    readonly prototype: SVGAnimateTransformElement;
+    prototype: SVGAnimateTransformElement;
     new(): SVGAnimateTransformElement;
 };
 
@@ -12103,7 +12103,7 @@ interface SVGAnimatedAngle {
 }
 
 declare var SVGAnimatedAngle: {
-    readonly prototype: SVGAnimatedAngle;
+    prototype: SVGAnimatedAngle;
     new(): SVGAnimatedAngle;
 };
 
@@ -12114,7 +12114,7 @@ interface SVGAnimatedBoolean {
 }
 
 declare var SVGAnimatedBoolean: {
-    readonly prototype: SVGAnimatedBoolean;
+    prototype: SVGAnimatedBoolean;
     new(): SVGAnimatedBoolean;
 };
 
@@ -12125,7 +12125,7 @@ interface SVGAnimatedEnumeration {
 }
 
 declare var SVGAnimatedEnumeration: {
-    readonly prototype: SVGAnimatedEnumeration;
+    prototype: SVGAnimatedEnumeration;
     new(): SVGAnimatedEnumeration;
 };
 
@@ -12136,7 +12136,7 @@ interface SVGAnimatedInteger {
 }
 
 declare var SVGAnimatedInteger: {
-    readonly prototype: SVGAnimatedInteger;
+    prototype: SVGAnimatedInteger;
     new(): SVGAnimatedInteger;
 };
 
@@ -12147,7 +12147,7 @@ interface SVGAnimatedLength {
 }
 
 declare var SVGAnimatedLength: {
-    readonly prototype: SVGAnimatedLength;
+    prototype: SVGAnimatedLength;
     new(): SVGAnimatedLength;
 };
 
@@ -12158,7 +12158,7 @@ interface SVGAnimatedLengthList {
 }
 
 declare var SVGAnimatedLengthList: {
-    readonly prototype: SVGAnimatedLengthList;
+    prototype: SVGAnimatedLengthList;
     new(): SVGAnimatedLengthList;
 };
 
@@ -12169,7 +12169,7 @@ interface SVGAnimatedNumber {
 }
 
 declare var SVGAnimatedNumber: {
-    readonly prototype: SVGAnimatedNumber;
+    prototype: SVGAnimatedNumber;
     new(): SVGAnimatedNumber;
 };
 
@@ -12180,7 +12180,7 @@ interface SVGAnimatedNumberList {
 }
 
 declare var SVGAnimatedNumberList: {
-    readonly prototype: SVGAnimatedNumberList;
+    prototype: SVGAnimatedNumberList;
     new(): SVGAnimatedNumberList;
 };
 
@@ -12196,7 +12196,7 @@ interface SVGAnimatedPreserveAspectRatio {
 }
 
 declare var SVGAnimatedPreserveAspectRatio: {
-    readonly prototype: SVGAnimatedPreserveAspectRatio;
+    prototype: SVGAnimatedPreserveAspectRatio;
     new(): SVGAnimatedPreserveAspectRatio;
 };
 
@@ -12207,7 +12207,7 @@ interface SVGAnimatedRect {
 }
 
 declare var SVGAnimatedRect: {
-    readonly prototype: SVGAnimatedRect;
+    prototype: SVGAnimatedRect;
     new(): SVGAnimatedRect;
 };
 
@@ -12218,7 +12218,7 @@ interface SVGAnimatedString {
 }
 
 declare var SVGAnimatedString: {
-    readonly prototype: SVGAnimatedString;
+    prototype: SVGAnimatedString;
     new(): SVGAnimatedString;
 };
 
@@ -12229,7 +12229,7 @@ interface SVGAnimatedTransformList {
 }
 
 declare var SVGAnimatedTransformList: {
-    readonly prototype: SVGAnimatedTransformList;
+    prototype: SVGAnimatedTransformList;
     new(): SVGAnimatedTransformList;
 };
 
@@ -12249,7 +12249,7 @@ interface SVGAnimationElement extends SVGElement, SVGTests {
 }
 
 declare var SVGAnimationElement: {
-    readonly prototype: SVGAnimationElement;
+    prototype: SVGAnimationElement;
     new(): SVGAnimationElement;
 };
 
@@ -12265,7 +12265,7 @@ interface SVGCircleElement extends SVGGeometryElement {
 }
 
 declare var SVGCircleElement: {
-    readonly prototype: SVGCircleElement;
+    prototype: SVGCircleElement;
     new(): SVGCircleElement;
 };
 
@@ -12280,7 +12280,7 @@ interface SVGClipPathElement extends SVGElement {
 }
 
 declare var SVGClipPathElement: {
-    readonly prototype: SVGClipPathElement;
+    prototype: SVGClipPathElement;
     new(): SVGClipPathElement;
 };
 
@@ -12306,7 +12306,7 @@ interface SVGComponentTransferFunctionElement extends SVGElement {
 }
 
 declare var SVGComponentTransferFunctionElement: {
-    readonly prototype: SVGComponentTransferFunctionElement;
+    prototype: SVGComponentTransferFunctionElement;
     new(): SVGComponentTransferFunctionElement;
     readonly SVG_FECOMPONENTTRANSFER_TYPE_DISCRETE: number;
     readonly SVG_FECOMPONENTTRANSFER_TYPE_GAMMA: number;
@@ -12326,7 +12326,7 @@ interface SVGCursorElement extends SVGElement {
 }
 
 declare var SVGCursorElement: {
-    readonly prototype: SVGCursorElement;
+    prototype: SVGCursorElement;
     new(): SVGCursorElement;
 };
 
@@ -12339,7 +12339,7 @@ interface SVGDefsElement extends SVGGraphicsElement {
 }
 
 declare var SVGDefsElement: {
-    readonly prototype: SVGDefsElement;
+    prototype: SVGDefsElement;
     new(): SVGDefsElement;
 };
 
@@ -12352,7 +12352,7 @@ interface SVGDescElement extends SVGElement {
 }
 
 declare var SVGDescElement: {
-    readonly prototype: SVGDescElement;
+    prototype: SVGDescElement;
     new(): SVGDescElement;
 };
 
@@ -12372,7 +12372,7 @@ interface SVGElement extends Element, DocumentAndElementEventHandlers, DocumentA
 }
 
 declare var SVGElement: {
-    readonly prototype: SVGElement;
+    prototype: SVGElement;
     new(): SVGElement;
 };
 
@@ -12389,7 +12389,7 @@ interface SVGEllipseElement extends SVGGeometryElement {
 }
 
 declare var SVGEllipseElement: {
-    readonly prototype: SVGEllipseElement;
+    prototype: SVGEllipseElement;
     new(): SVGEllipseElement;
 };
 
@@ -12422,7 +12422,7 @@ interface SVGFEBlendElement extends SVGElement, SVGFilterPrimitiveStandardAttrib
 }
 
 declare var SVGFEBlendElement: {
-    readonly prototype: SVGFEBlendElement;
+    prototype: SVGFEBlendElement;
     new(): SVGFEBlendElement;
     readonly SVG_FEBLEND_MODE_COLOR: number;
     readonly SVG_FEBLEND_MODE_COLOR_BURN: number;
@@ -12460,7 +12460,7 @@ interface SVGFEColorMatrixElement extends SVGElement, SVGFilterPrimitiveStandard
 }
 
 declare var SVGFEColorMatrixElement: {
-    readonly prototype: SVGFEColorMatrixElement;
+    prototype: SVGFEColorMatrixElement;
     new(): SVGFEColorMatrixElement;
     readonly SVG_FECOLORMATRIX_TYPE_HUEROTATE: number;
     readonly SVG_FECOLORMATRIX_TYPE_LUMINANCETOALPHA: number;
@@ -12479,7 +12479,7 @@ interface SVGFEComponentTransferElement extends SVGElement, SVGFilterPrimitiveSt
 }
 
 declare var SVGFEComponentTransferElement: {
-    readonly prototype: SVGFEComponentTransferElement;
+    prototype: SVGFEComponentTransferElement;
     new(): SVGFEComponentTransferElement;
 };
 
@@ -12506,7 +12506,7 @@ interface SVGFECompositeElement extends SVGElement, SVGFilterPrimitiveStandardAt
 }
 
 declare var SVGFECompositeElement: {
-    readonly prototype: SVGFECompositeElement;
+    prototype: SVGFECompositeElement;
     new(): SVGFECompositeElement;
     readonly SVG_FECOMPOSITE_OPERATOR_ARITHMETIC: number;
     readonly SVG_FECOMPOSITE_OPERATOR_ATOP: number;
@@ -12542,7 +12542,7 @@ interface SVGFEConvolveMatrixElement extends SVGElement, SVGFilterPrimitiveStand
 }
 
 declare var SVGFEConvolveMatrixElement: {
-    readonly prototype: SVGFEConvolveMatrixElement;
+    prototype: SVGFEConvolveMatrixElement;
     new(): SVGFEConvolveMatrixElement;
     readonly SVG_EDGEMODE_DUPLICATE: number;
     readonly SVG_EDGEMODE_NONE: number;
@@ -12564,7 +12564,7 @@ interface SVGFEDiffuseLightingElement extends SVGElement, SVGFilterPrimitiveStan
 }
 
 declare var SVGFEDiffuseLightingElement: {
-    readonly prototype: SVGFEDiffuseLightingElement;
+    prototype: SVGFEDiffuseLightingElement;
     new(): SVGFEDiffuseLightingElement;
 };
 
@@ -12587,7 +12587,7 @@ interface SVGFEDisplacementMapElement extends SVGElement, SVGFilterPrimitiveStan
 }
 
 declare var SVGFEDisplacementMapElement: {
-    readonly prototype: SVGFEDisplacementMapElement;
+    prototype: SVGFEDisplacementMapElement;
     new(): SVGFEDisplacementMapElement;
     readonly SVG_CHANNEL_A: number;
     readonly SVG_CHANNEL_B: number;
@@ -12607,7 +12607,7 @@ interface SVGFEDistantLightElement extends SVGElement {
 }
 
 declare var SVGFEDistantLightElement: {
-    readonly prototype: SVGFEDistantLightElement;
+    prototype: SVGFEDistantLightElement;
     new(): SVGFEDistantLightElement;
 };
 
@@ -12625,7 +12625,7 @@ interface SVGFEDropShadowElement extends SVGElement, SVGFilterPrimitiveStandardA
 }
 
 declare var SVGFEDropShadowElement: {
-    readonly prototype: SVGFEDropShadowElement;
+    prototype: SVGFEDropShadowElement;
     new(): SVGFEDropShadowElement;
 };
 
@@ -12638,7 +12638,7 @@ interface SVGFEFloodElement extends SVGElement, SVGFilterPrimitiveStandardAttrib
 }
 
 declare var SVGFEFloodElement: {
-    readonly prototype: SVGFEFloodElement;
+    prototype: SVGFEFloodElement;
     new(): SVGFEFloodElement;
 };
 
@@ -12651,7 +12651,7 @@ interface SVGFEFuncAElement extends SVGComponentTransferFunctionElement {
 }
 
 declare var SVGFEFuncAElement: {
-    readonly prototype: SVGFEFuncAElement;
+    prototype: SVGFEFuncAElement;
     new(): SVGFEFuncAElement;
 };
 
@@ -12664,7 +12664,7 @@ interface SVGFEFuncBElement extends SVGComponentTransferFunctionElement {
 }
 
 declare var SVGFEFuncBElement: {
-    readonly prototype: SVGFEFuncBElement;
+    prototype: SVGFEFuncBElement;
     new(): SVGFEFuncBElement;
 };
 
@@ -12677,7 +12677,7 @@ interface SVGFEFuncGElement extends SVGComponentTransferFunctionElement {
 }
 
 declare var SVGFEFuncGElement: {
-    readonly prototype: SVGFEFuncGElement;
+    prototype: SVGFEFuncGElement;
     new(): SVGFEFuncGElement;
 };
 
@@ -12690,7 +12690,7 @@ interface SVGFEFuncRElement extends SVGComponentTransferFunctionElement {
 }
 
 declare var SVGFEFuncRElement: {
-    readonly prototype: SVGFEFuncRElement;
+    prototype: SVGFEFuncRElement;
     new(): SVGFEFuncRElement;
 };
 
@@ -12707,7 +12707,7 @@ interface SVGFEGaussianBlurElement extends SVGElement, SVGFilterPrimitiveStandar
 }
 
 declare var SVGFEGaussianBlurElement: {
-    readonly prototype: SVGFEGaussianBlurElement;
+    prototype: SVGFEGaussianBlurElement;
     new(): SVGFEGaussianBlurElement;
 };
 
@@ -12721,7 +12721,7 @@ interface SVGFEImageElement extends SVGElement, SVGFilterPrimitiveStandardAttrib
 }
 
 declare var SVGFEImageElement: {
-    readonly prototype: SVGFEImageElement;
+    prototype: SVGFEImageElement;
     new(): SVGFEImageElement;
 };
 
@@ -12734,7 +12734,7 @@ interface SVGFEMergeElement extends SVGElement, SVGFilterPrimitiveStandardAttrib
 }
 
 declare var SVGFEMergeElement: {
-    readonly prototype: SVGFEMergeElement;
+    prototype: SVGFEMergeElement;
     new(): SVGFEMergeElement;
 };
 
@@ -12748,7 +12748,7 @@ interface SVGFEMergeNodeElement extends SVGElement {
 }
 
 declare var SVGFEMergeNodeElement: {
-    readonly prototype: SVGFEMergeNodeElement;
+    prototype: SVGFEMergeNodeElement;
     new(): SVGFEMergeNodeElement;
 };
 
@@ -12768,7 +12768,7 @@ interface SVGFEMorphologyElement extends SVGElement, SVGFilterPrimitiveStandardA
 }
 
 declare var SVGFEMorphologyElement: {
-    readonly prototype: SVGFEMorphologyElement;
+    prototype: SVGFEMorphologyElement;
     new(): SVGFEMorphologyElement;
     readonly SVG_MORPHOLOGY_OPERATOR_DILATE: number;
     readonly SVG_MORPHOLOGY_OPERATOR_ERODE: number;
@@ -12787,7 +12787,7 @@ interface SVGFEOffsetElement extends SVGElement, SVGFilterPrimitiveStandardAttri
 }
 
 declare var SVGFEOffsetElement: {
-    readonly prototype: SVGFEOffsetElement;
+    prototype: SVGFEOffsetElement;
     new(): SVGFEOffsetElement;
 };
 
@@ -12803,7 +12803,7 @@ interface SVGFEPointLightElement extends SVGElement {
 }
 
 declare var SVGFEPointLightElement: {
-    readonly prototype: SVGFEPointLightElement;
+    prototype: SVGFEPointLightElement;
     new(): SVGFEPointLightElement;
 };
 
@@ -12822,7 +12822,7 @@ interface SVGFESpecularLightingElement extends SVGElement, SVGFilterPrimitiveSta
 }
 
 declare var SVGFESpecularLightingElement: {
-    readonly prototype: SVGFESpecularLightingElement;
+    prototype: SVGFESpecularLightingElement;
     new(): SVGFESpecularLightingElement;
 };
 
@@ -12843,7 +12843,7 @@ interface SVGFESpotLightElement extends SVGElement {
 }
 
 declare var SVGFESpotLightElement: {
-    readonly prototype: SVGFESpotLightElement;
+    prototype: SVGFESpotLightElement;
     new(): SVGFESpotLightElement;
 };
 
@@ -12857,7 +12857,7 @@ interface SVGFETileElement extends SVGElement, SVGFilterPrimitiveStandardAttribu
 }
 
 declare var SVGFETileElement: {
-    readonly prototype: SVGFETileElement;
+    prototype: SVGFETileElement;
     new(): SVGFETileElement;
 };
 
@@ -12882,7 +12882,7 @@ interface SVGFETurbulenceElement extends SVGElement, SVGFilterPrimitiveStandardA
 }
 
 declare var SVGFETurbulenceElement: {
-    readonly prototype: SVGFETurbulenceElement;
+    prototype: SVGFETurbulenceElement;
     new(): SVGFETurbulenceElement;
     readonly SVG_STITCHTYPE_NOSTITCH: number;
     readonly SVG_STITCHTYPE_STITCH: number;
@@ -12907,7 +12907,7 @@ interface SVGFilterElement extends SVGElement, SVGURIReference {
 }
 
 declare var SVGFilterElement: {
-    readonly prototype: SVGFilterElement;
+    prototype: SVGFilterElement;
     new(): SVGFilterElement;
 };
 
@@ -12937,7 +12937,7 @@ interface SVGForeignObjectElement extends SVGGraphicsElement {
 }
 
 declare var SVGForeignObjectElement: {
-    readonly prototype: SVGForeignObjectElement;
+    prototype: SVGForeignObjectElement;
     new(): SVGForeignObjectElement;
 };
 
@@ -12950,7 +12950,7 @@ interface SVGGElement extends SVGGraphicsElement {
 }
 
 declare var SVGGElement: {
-    readonly prototype: SVGGElement;
+    prototype: SVGGElement;
     new(): SVGGElement;
 };
 
@@ -12967,7 +12967,7 @@ interface SVGGeometryElement extends SVGGraphicsElement {
 }
 
 declare var SVGGeometryElement: {
-    readonly prototype: SVGGeometryElement;
+    prototype: SVGGeometryElement;
     new(): SVGGeometryElement;
 };
 
@@ -12987,7 +12987,7 @@ interface SVGGradientElement extends SVGElement, SVGURIReference {
 }
 
 declare var SVGGradientElement: {
-    readonly prototype: SVGGradientElement;
+    prototype: SVGGradientElement;
     new(): SVGGradientElement;
     readonly SVG_SPREADMETHOD_PAD: number;
     readonly SVG_SPREADMETHOD_REFLECT: number;
@@ -13008,7 +13008,7 @@ interface SVGGraphicsElement extends SVGElement, SVGTests {
 }
 
 declare var SVGGraphicsElement: {
-    readonly prototype: SVGGraphicsElement;
+    prototype: SVGGraphicsElement;
     new(): SVGGraphicsElement;
 };
 
@@ -13026,7 +13026,7 @@ interface SVGImageElement extends SVGGraphicsElement, SVGURIReference {
 }
 
 declare var SVGImageElement: {
-    readonly prototype: SVGImageElement;
+    prototype: SVGImageElement;
     new(): SVGImageElement;
 };
 
@@ -13052,7 +13052,7 @@ interface SVGLength {
 }
 
 declare var SVGLength: {
-    readonly prototype: SVGLength;
+    prototype: SVGLength;
     new(): SVGLength;
     readonly SVG_LENGTHTYPE_CM: number;
     readonly SVG_LENGTHTYPE_EMS: number;
@@ -13082,7 +13082,7 @@ interface SVGLengthList {
 }
 
 declare var SVGLengthList: {
-    readonly prototype: SVGLengthList;
+    prototype: SVGLengthList;
     new(): SVGLengthList;
 };
 
@@ -13099,7 +13099,7 @@ interface SVGLineElement extends SVGGeometryElement {
 }
 
 declare var SVGLineElement: {
-    readonly prototype: SVGLineElement;
+    prototype: SVGLineElement;
     new(): SVGLineElement;
 };
 
@@ -13116,7 +13116,7 @@ interface SVGLinearGradientElement extends SVGGradientElement {
 }
 
 declare var SVGLinearGradientElement: {
-    readonly prototype: SVGLinearGradientElement;
+    prototype: SVGLinearGradientElement;
     new(): SVGLinearGradientElement;
 };
 
@@ -13128,7 +13128,7 @@ interface SVGMPathElement extends SVGElement, SVGURIReference {
 }
 
 declare var SVGMPathElement: {
-    readonly prototype: SVGMPathElement;
+    prototype: SVGMPathElement;
     new(): SVGMPathElement;
 };
 
@@ -13155,7 +13155,7 @@ interface SVGMarkerElement extends SVGElement, SVGFitToViewBox {
 }
 
 declare var SVGMarkerElement: {
-    readonly prototype: SVGMarkerElement;
+    prototype: SVGMarkerElement;
     new(): SVGMarkerElement;
     readonly SVG_MARKERUNITS_STROKEWIDTH: number;
     readonly SVG_MARKERUNITS_UNKNOWN: number;
@@ -13180,7 +13180,7 @@ interface SVGMaskElement extends SVGElement {
 }
 
 declare var SVGMaskElement: {
-    readonly prototype: SVGMaskElement;
+    prototype: SVGMaskElement;
     new(): SVGMaskElement;
 };
 
@@ -13193,7 +13193,7 @@ interface SVGMetadataElement extends SVGElement {
 }
 
 declare var SVGMetadataElement: {
-    readonly prototype: SVGMetadataElement;
+    prototype: SVGMetadataElement;
     new(): SVGMetadataElement;
 };
 
@@ -13203,7 +13203,7 @@ interface SVGNumber {
 }
 
 declare var SVGNumber: {
-    readonly prototype: SVGNumber;
+    prototype: SVGNumber;
     new(): SVGNumber;
 };
 
@@ -13222,7 +13222,7 @@ interface SVGNumberList {
 }
 
 declare var SVGNumberList: {
-    readonly prototype: SVGNumberList;
+    prototype: SVGNumberList;
     new(): SVGNumberList;
 };
 
@@ -13235,7 +13235,7 @@ interface SVGPathElement extends SVGGeometryElement {
 }
 
 declare var SVGPathElement: {
-    readonly prototype: SVGPathElement;
+    prototype: SVGPathElement;
     new(): SVGPathElement;
 };
 
@@ -13255,7 +13255,7 @@ interface SVGPatternElement extends SVGElement, SVGFitToViewBox, SVGURIReference
 }
 
 declare var SVGPatternElement: {
-    readonly prototype: SVGPatternElement;
+    prototype: SVGPatternElement;
     new(): SVGPatternElement;
 };
 
@@ -13273,7 +13273,7 @@ interface SVGPointList {
 }
 
 declare var SVGPointList: {
-    readonly prototype: SVGPointList;
+    prototype: SVGPointList;
     new(): SVGPointList;
 };
 
@@ -13286,7 +13286,7 @@ interface SVGPolygonElement extends SVGGeometryElement, SVGAnimatedPoints {
 }
 
 declare var SVGPolygonElement: {
-    readonly prototype: SVGPolygonElement;
+    prototype: SVGPolygonElement;
     new(): SVGPolygonElement;
 };
 
@@ -13299,7 +13299,7 @@ interface SVGPolylineElement extends SVGGeometryElement, SVGAnimatedPoints {
 }
 
 declare var SVGPolylineElement: {
-    readonly prototype: SVGPolylineElement;
+    prototype: SVGPolylineElement;
     new(): SVGPolylineElement;
 };
 
@@ -13324,7 +13324,7 @@ interface SVGPreserveAspectRatio {
 }
 
 declare var SVGPreserveAspectRatio: {
-    readonly prototype: SVGPreserveAspectRatio;
+    prototype: SVGPreserveAspectRatio;
     new(): SVGPreserveAspectRatio;
     readonly SVG_MEETORSLICE_MEET: number;
     readonly SVG_MEETORSLICE_SLICE: number;
@@ -13357,7 +13357,7 @@ interface SVGRadialGradientElement extends SVGGradientElement {
 }
 
 declare var SVGRadialGradientElement: {
-    readonly prototype: SVGRadialGradientElement;
+    prototype: SVGRadialGradientElement;
     new(): SVGRadialGradientElement;
 };
 
@@ -13376,7 +13376,7 @@ interface SVGRectElement extends SVGGeometryElement {
 }
 
 declare var SVGRectElement: {
-    readonly prototype: SVGRectElement;
+    prototype: SVGRectElement;
     new(): SVGRectElement;
 };
 
@@ -13425,7 +13425,7 @@ interface SVGSVGElement extends SVGGraphicsElement, SVGFitToViewBox, WindowEvent
 }
 
 declare var SVGSVGElement: {
-    readonly prototype: SVGSVGElement;
+    prototype: SVGSVGElement;
     new(): SVGSVGElement;
 };
 
@@ -13439,7 +13439,7 @@ interface SVGScriptElement extends SVGElement, SVGURIReference {
 }
 
 declare var SVGScriptElement: {
-    readonly prototype: SVGScriptElement;
+    prototype: SVGScriptElement;
     new(): SVGScriptElement;
 };
 
@@ -13451,7 +13451,7 @@ interface SVGSetElement extends SVGAnimationElement {
 }
 
 declare var SVGSetElement: {
-    readonly prototype: SVGSetElement;
+    prototype: SVGSetElement;
     new(): SVGSetElement;
 };
 
@@ -13465,7 +13465,7 @@ interface SVGStopElement extends SVGElement {
 }
 
 declare var SVGStopElement: {
-    readonly prototype: SVGStopElement;
+    prototype: SVGStopElement;
     new(): SVGStopElement;
 };
 
@@ -13484,7 +13484,7 @@ interface SVGStringList {
 }
 
 declare var SVGStringList: {
-    readonly prototype: SVGStringList;
+    prototype: SVGStringList;
     new(): SVGStringList;
 };
 
@@ -13501,7 +13501,7 @@ interface SVGStyleElement extends SVGElement, LinkStyle {
 }
 
 declare var SVGStyleElement: {
-    readonly prototype: SVGStyleElement;
+    prototype: SVGStyleElement;
     new(): SVGStyleElement;
 };
 
@@ -13514,7 +13514,7 @@ interface SVGSwitchElement extends SVGGraphicsElement {
 }
 
 declare var SVGSwitchElement: {
-    readonly prototype: SVGSwitchElement;
+    prototype: SVGSwitchElement;
     new(): SVGSwitchElement;
 };
 
@@ -13527,7 +13527,7 @@ interface SVGSymbolElement extends SVGElement, SVGFitToViewBox {
 }
 
 declare var SVGSymbolElement: {
-    readonly prototype: SVGSymbolElement;
+    prototype: SVGSymbolElement;
     new(): SVGSymbolElement;
 };
 
@@ -13540,7 +13540,7 @@ interface SVGTSpanElement extends SVGTextPositioningElement {
 }
 
 declare var SVGTSpanElement: {
-    readonly prototype: SVGTSpanElement;
+    prototype: SVGTSpanElement;
     new(): SVGTSpanElement;
 };
 
@@ -13573,7 +13573,7 @@ interface SVGTextContentElement extends SVGGraphicsElement {
 }
 
 declare var SVGTextContentElement: {
-    readonly prototype: SVGTextContentElement;
+    prototype: SVGTextContentElement;
     new(): SVGTextContentElement;
     readonly LENGTHADJUST_SPACING: number;
     readonly LENGTHADJUST_SPACINGANDGLYPHS: number;
@@ -13589,7 +13589,7 @@ interface SVGTextElement extends SVGTextPositioningElement {
 }
 
 declare var SVGTextElement: {
-    readonly prototype: SVGTextElement;
+    prototype: SVGTextElement;
     new(): SVGTextElement;
 };
 
@@ -13611,7 +13611,7 @@ interface SVGTextPathElement extends SVGTextContentElement, SVGURIReference {
 }
 
 declare var SVGTextPathElement: {
-    readonly prototype: SVGTextPathElement;
+    prototype: SVGTextPathElement;
     new(): SVGTextPathElement;
     readonly TEXTPATH_METHODTYPE_ALIGN: number;
     readonly TEXTPATH_METHODTYPE_STRETCH: number;
@@ -13635,7 +13635,7 @@ interface SVGTextPositioningElement extends SVGTextContentElement {
 }
 
 declare var SVGTextPositioningElement: {
-    readonly prototype: SVGTextPositioningElement;
+    prototype: SVGTextPositioningElement;
     new(): SVGTextPositioningElement;
 };
 
@@ -13648,7 +13648,7 @@ interface SVGTitleElement extends SVGElement {
 }
 
 declare var SVGTitleElement: {
-    readonly prototype: SVGTitleElement;
+    prototype: SVGTitleElement;
     new(): SVGTitleElement;
 };
 
@@ -13673,7 +13673,7 @@ interface SVGTransform {
 }
 
 declare var SVGTransform: {
-    readonly prototype: SVGTransform;
+    prototype: SVGTransform;
     new(): SVGTransform;
     readonly SVG_TRANSFORM_MATRIX: number;
     readonly SVG_TRANSFORM_ROTATE: number;
@@ -13701,7 +13701,7 @@ interface SVGTransformList {
 }
 
 declare var SVGTransformList: {
-    readonly prototype: SVGTransformList;
+    prototype: SVGTransformList;
     new(): SVGTransformList;
 };
 
@@ -13717,7 +13717,7 @@ interface SVGUnitTypes {
 }
 
 declare var SVGUnitTypes: {
-    readonly prototype: SVGUnitTypes;
+    prototype: SVGUnitTypes;
     new(): SVGUnitTypes;
     readonly SVG_UNIT_TYPE_OBJECTBOUNDINGBOX: number;
     readonly SVG_UNIT_TYPE_UNKNOWN: number;
@@ -13737,7 +13737,7 @@ interface SVGUseElement extends SVGGraphicsElement, SVGURIReference {
 }
 
 declare var SVGUseElement: {
-    readonly prototype: SVGUseElement;
+    prototype: SVGUseElement;
     new(): SVGUseElement;
 };
 
@@ -13750,7 +13750,7 @@ interface SVGViewElement extends SVGElement, SVGFitToViewBox {
 }
 
 declare var SVGViewElement: {
-    readonly prototype: SVGViewElement;
+    prototype: SVGViewElement;
     new(): SVGViewElement;
 };
 
@@ -13766,7 +13766,7 @@ interface Screen {
 }
 
 declare var Screen: {
-    readonly prototype: Screen;
+    prototype: Screen;
     new(): Screen;
 };
 
@@ -13787,7 +13787,7 @@ interface ScreenOrientation extends EventTarget {
 }
 
 declare var ScreenOrientation: {
-    readonly prototype: ScreenOrientation;
+    prototype: ScreenOrientation;
     new(): ScreenOrientation;
 };
 
@@ -13810,7 +13810,7 @@ interface ScriptProcessorNode extends AudioNode {
 
 /** @deprecated */
 declare var ScriptProcessorNode: {
-    readonly prototype: ScriptProcessorNode;
+    prototype: ScriptProcessorNode;
     new(): ScriptProcessorNode;
 };
 
@@ -13831,7 +13831,7 @@ interface SecurityPolicyViolationEvent extends Event {
 }
 
 declare var SecurityPolicyViolationEvent: {
-    readonly prototype: SecurityPolicyViolationEvent;
+    prototype: SecurityPolicyViolationEvent;
     new(type: string, eventInitDict?: SecurityPolicyViolationEventInit): SecurityPolicyViolationEvent;
 };
 
@@ -13862,7 +13862,7 @@ interface Selection {
 }
 
 declare var Selection: {
-    readonly prototype: Selection;
+    prototype: Selection;
     new(): Selection;
     toString(): string;
 };
@@ -13885,7 +13885,7 @@ interface ServiceWorker extends EventTarget, AbstractWorker {
 }
 
 declare var ServiceWorker: {
-    readonly prototype: ServiceWorker;
+    prototype: ServiceWorker;
     new(): ServiceWorker;
 };
 
@@ -13913,7 +13913,7 @@ interface ServiceWorkerContainer extends EventTarget {
 }
 
 declare var ServiceWorkerContainer: {
-    readonly prototype: ServiceWorkerContainer;
+    prototype: ServiceWorkerContainer;
     new(): ServiceWorkerContainer;
 };
 
@@ -13941,7 +13941,7 @@ interface ServiceWorkerRegistration extends EventTarget {
 }
 
 declare var ServiceWorkerRegistration: {
-    readonly prototype: ServiceWorkerRegistration;
+    prototype: ServiceWorkerRegistration;
     new(): ServiceWorkerRegistration;
 };
 
@@ -13954,7 +13954,7 @@ interface ShadowRoot extends DocumentFragment, DocumentOrShadowRoot, InnerHTML {
 }
 
 declare var ShadowRoot: {
-    readonly prototype: ShadowRoot;
+    prototype: ShadowRoot;
     new(): ShadowRoot;
 };
 
@@ -13970,7 +13970,7 @@ interface SharedWorker extends EventTarget, AbstractWorker {
 }
 
 declare var SharedWorker: {
-    readonly prototype: SharedWorker;
+    prototype: SharedWorker;
     new(scriptURL: string | URL, options?: string | WorkerOptions): SharedWorker;
 };
 
@@ -14010,7 +14010,7 @@ interface SourceBuffer extends EventTarget {
 }
 
 declare var SourceBuffer: {
-    readonly prototype: SourceBuffer;
+    prototype: SourceBuffer;
     new(): SourceBuffer;
 };
 
@@ -14032,7 +14032,7 @@ interface SourceBufferList extends EventTarget {
 }
 
 declare var SourceBufferList: {
-    readonly prototype: SourceBufferList;
+    prototype: SourceBufferList;
     new(): SourceBufferList;
 };
 
@@ -14042,7 +14042,7 @@ interface SpeechRecognitionAlternative {
 }
 
 declare var SpeechRecognitionAlternative: {
-    readonly prototype: SpeechRecognitionAlternative;
+    prototype: SpeechRecognitionAlternative;
     new(): SpeechRecognitionAlternative;
 };
 
@@ -14052,7 +14052,7 @@ interface SpeechRecognitionErrorEvent extends Event {
 }
 
 declare var SpeechRecognitionErrorEvent: {
-    readonly prototype: SpeechRecognitionErrorEvent;
+    prototype: SpeechRecognitionErrorEvent;
     new(type: string, eventInitDict: SpeechRecognitionErrorEventInit): SpeechRecognitionErrorEvent;
 };
 
@@ -14064,7 +14064,7 @@ interface SpeechRecognitionResult {
 }
 
 declare var SpeechRecognitionResult: {
-    readonly prototype: SpeechRecognitionResult;
+    prototype: SpeechRecognitionResult;
     new(): SpeechRecognitionResult;
 };
 
@@ -14075,7 +14075,7 @@ interface SpeechRecognitionResultList {
 }
 
 declare var SpeechRecognitionResultList: {
-    readonly prototype: SpeechRecognitionResultList;
+    prototype: SpeechRecognitionResultList;
     new(): SpeechRecognitionResultList;
 };
 
@@ -14101,7 +14101,7 @@ interface SpeechSynthesis extends EventTarget {
 }
 
 declare var SpeechSynthesis: {
-    readonly prototype: SpeechSynthesis;
+    prototype: SpeechSynthesis;
     new(): SpeechSynthesis;
 };
 
@@ -14110,7 +14110,7 @@ interface SpeechSynthesisErrorEvent extends SpeechSynthesisEvent {
 }
 
 declare var SpeechSynthesisErrorEvent: {
-    readonly prototype: SpeechSynthesisErrorEvent;
+    prototype: SpeechSynthesisErrorEvent;
     new(type: string, eventInitDict: SpeechSynthesisErrorEventInit): SpeechSynthesisErrorEvent;
 };
 
@@ -14124,7 +14124,7 @@ interface SpeechSynthesisEvent extends Event {
 }
 
 declare var SpeechSynthesisEvent: {
-    readonly prototype: SpeechSynthesisEvent;
+    prototype: SpeechSynthesisEvent;
     new(type: string, eventInitDict: SpeechSynthesisEventInit): SpeechSynthesisEvent;
 };
 
@@ -14160,7 +14160,7 @@ interface SpeechSynthesisUtterance extends EventTarget {
 }
 
 declare var SpeechSynthesisUtterance: {
-    readonly prototype: SpeechSynthesisUtterance;
+    prototype: SpeechSynthesisUtterance;
     new(text?: string): SpeechSynthesisUtterance;
 };
 
@@ -14174,7 +14174,7 @@ interface SpeechSynthesisVoice {
 }
 
 declare var SpeechSynthesisVoice: {
-    readonly prototype: SpeechSynthesisVoice;
+    prototype: SpeechSynthesisVoice;
     new(): SpeechSynthesisVoice;
 };
 
@@ -14182,7 +14182,7 @@ interface StaticRange extends AbstractRange {
 }
 
 declare var StaticRange: {
-    readonly prototype: StaticRange;
+    prototype: StaticRange;
     new(init: StaticRangeInit): StaticRange;
 };
 
@@ -14192,7 +14192,7 @@ interface StereoPannerNode extends AudioNode {
 }
 
 declare var StereoPannerNode: {
-    readonly prototype: StereoPannerNode;
+    prototype: StereoPannerNode;
     new(context: BaseAudioContext, options?: StereoPannerOptions): StereoPannerNode;
 };
 
@@ -14234,7 +14234,7 @@ interface Storage {
 }
 
 declare var Storage: {
-    readonly prototype: Storage;
+    prototype: Storage;
     new(): Storage;
 };
 
@@ -14264,7 +14264,7 @@ interface StorageEvent extends Event {
 }
 
 declare var StorageEvent: {
-    readonly prototype: StorageEvent;
+    prototype: StorageEvent;
     new(type: string, eventInitDict?: StorageEventInit): StorageEvent;
 };
 
@@ -14275,7 +14275,7 @@ interface StorageManager {
 }
 
 declare var StorageManager: {
-    readonly prototype: StorageManager;
+    prototype: StorageManager;
     new(): StorageManager;
 };
 
@@ -14291,7 +14291,7 @@ interface StyleSheet {
 }
 
 declare var StyleSheet: {
-    readonly prototype: StyleSheet;
+    prototype: StyleSheet;
     new(): StyleSheet;
 };
 
@@ -14303,7 +14303,7 @@ interface StyleSheetList {
 }
 
 declare var StyleSheetList: {
-    readonly prototype: StyleSheetList;
+    prototype: StyleSheetList;
     new(): StyleSheetList;
 };
 
@@ -14315,7 +14315,7 @@ interface SubmitEvent extends Event {
 }
 
 declare var SubmitEvent: {
-    readonly prototype: SubmitEvent;
+    prototype: SubmitEvent;
     new(type: string, eventInitDict?: SubmitEventInit): SubmitEvent;
 };
 
@@ -14340,7 +14340,7 @@ interface SubtleCrypto {
 }
 
 declare var SubtleCrypto: {
-    readonly prototype: SubtleCrypto;
+    prototype: SubtleCrypto;
     new(): SubtleCrypto;
 };
 
@@ -14358,7 +14358,7 @@ interface Text extends CharacterData, Slottable {
 }
 
 declare var Text: {
-    readonly prototype: Text;
+    prototype: Text;
     new(data?: string): Text;
 };
 
@@ -14381,7 +14381,7 @@ interface TextDecoder extends TextDecoderCommon {
 }
 
 declare var TextDecoder: {
-    readonly prototype: TextDecoder;
+    prototype: TextDecoder;
     new(label?: string, options?: TextDecoderOptions): TextDecoder;
 };
 
@@ -14406,7 +14406,7 @@ interface TextDecoderStream extends GenericTransformStream, TextDecoderCommon {
 }
 
 declare var TextDecoderStream: {
-    readonly prototype: TextDecoderStream;
+    prototype: TextDecoderStream;
     new(label?: string, options?: TextDecoderOptions): TextDecoderStream;
 };
 
@@ -14423,7 +14423,7 @@ interface TextEncoder extends TextEncoderCommon {
 }
 
 declare var TextEncoder: {
-    readonly prototype: TextEncoder;
+    prototype: TextEncoder;
     new(): TextEncoder;
 };
 
@@ -14440,7 +14440,7 @@ interface TextEncoderStream extends GenericTransformStream, TextEncoderCommon {
 }
 
 declare var TextEncoderStream: {
-    readonly prototype: TextEncoderStream;
+    prototype: TextEncoderStream;
     new(): TextEncoderStream;
 };
 
@@ -14477,7 +14477,7 @@ interface TextMetrics {
 }
 
 declare var TextMetrics: {
-    readonly prototype: TextMetrics;
+    prototype: TextMetrics;
     new(): TextMetrics;
 };
 
@@ -14541,7 +14541,7 @@ interface TextTrack extends EventTarget {
 }
 
 declare var TextTrack: {
-    readonly prototype: TextTrack;
+    prototype: TextTrack;
     new(): TextTrack;
 };
 
@@ -14589,7 +14589,7 @@ interface TextTrackCue extends EventTarget {
 }
 
 declare var TextTrackCue: {
-    readonly prototype: TextTrackCue;
+    prototype: TextTrackCue;
     new(): TextTrackCue;
 };
 
@@ -14608,7 +14608,7 @@ interface TextTrackCueList {
 }
 
 declare var TextTrackCueList: {
-    readonly prototype: TextTrackCueList;
+    prototype: TextTrackCueList;
     new(): TextTrackCueList;
 };
 
@@ -14632,7 +14632,7 @@ interface TextTrackList extends EventTarget {
 }
 
 declare var TextTrackList: {
-    readonly prototype: TextTrackList;
+    prototype: TextTrackList;
     new(): TextTrackList;
 };
 
@@ -14657,7 +14657,7 @@ interface TimeRanges {
 }
 
 declare var TimeRanges: {
-    readonly prototype: TimeRanges;
+    prototype: TimeRanges;
     new(): TimeRanges;
 };
 
@@ -14678,7 +14678,7 @@ interface Touch {
 }
 
 declare var Touch: {
-    readonly prototype: Touch;
+    prototype: Touch;
     new(touchInitDict: TouchInit): Touch;
 };
 
@@ -14694,7 +14694,7 @@ interface TouchEvent extends UIEvent {
 }
 
 declare var TouchEvent: {
-    readonly prototype: TouchEvent;
+    prototype: TouchEvent;
     new(type: string, eventInitDict?: TouchEventInit): TouchEvent;
 };
 
@@ -14706,7 +14706,7 @@ interface TouchList {
 }
 
 declare var TouchList: {
-    readonly prototype: TouchList;
+    prototype: TouchList;
     new(): TouchList;
 };
 
@@ -14719,7 +14719,7 @@ interface TrackEvent extends Event {
 }
 
 declare var TrackEvent: {
-    readonly prototype: TrackEvent;
+    prototype: TrackEvent;
     new(type: string, eventInitDict?: TrackEventInit): TrackEvent;
 };
 
@@ -14729,7 +14729,7 @@ interface TransformStream<I = any, O = any> {
 }
 
 declare var TransformStream: {
-    readonly prototype: TransformStream;
+    prototype: TransformStream;
     new<I = any, O = any>(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>): TransformStream<I, O>;
 };
 
@@ -14741,7 +14741,7 @@ interface TransformStreamDefaultController<O = any> {
 }
 
 declare var TransformStreamDefaultController: {
-    readonly prototype: TransformStreamDefaultController;
+    prototype: TransformStreamDefaultController;
     new(): TransformStreamDefaultController;
 };
 
@@ -14753,7 +14753,7 @@ interface TransitionEvent extends Event {
 }
 
 declare var TransitionEvent: {
-    readonly prototype: TransitionEvent;
+    prototype: TransitionEvent;
     new(type: string, transitionEventInitDict?: TransitionEventInit): TransitionEvent;
 };
 
@@ -14773,7 +14773,7 @@ interface TreeWalker {
 }
 
 declare var TreeWalker: {
-    readonly prototype: TreeWalker;
+    prototype: TreeWalker;
     new(): TreeWalker;
 };
 
@@ -14788,7 +14788,7 @@ interface UIEvent extends Event {
 }
 
 declare var UIEvent: {
-    readonly prototype: UIEvent;
+    prototype: UIEvent;
     new(type: string, eventInitDict?: UIEventInit): UIEvent;
 };
 
@@ -14811,7 +14811,7 @@ interface URL {
 }
 
 declare var URL: {
-    readonly prototype: URL;
+    prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
     createObjectURL(object: any): string;
     revokeObjectURL(url: string): void;
@@ -14854,7 +14854,7 @@ interface URLSearchParams {
 }
 
 declare var URLSearchParams: {
-    readonly prototype: URLSearchParams;
+    prototype: URLSearchParams;
     new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
     toString(): string;
 };
@@ -14878,7 +14878,7 @@ interface VTTCue extends TextTrackCue {
 }
 
 declare var VTTCue: {
-    readonly prototype: VTTCue;
+    prototype: VTTCue;
     new(startTime: number, endTime: number, text: string): VTTCue;
 };
 
@@ -14894,7 +14894,7 @@ interface VTTRegion {
 }
 
 declare var VTTRegion: {
-    readonly prototype: VTTRegion;
+    prototype: VTTRegion;
     new(): VTTRegion;
 };
 
@@ -14914,7 +14914,7 @@ interface ValidityState {
 }
 
 declare var ValidityState: {
-    readonly prototype: ValidityState;
+    prototype: ValidityState;
     new(): ValidityState;
 };
 
@@ -14928,7 +14928,7 @@ interface VideoPlaybackQuality {
 }
 
 declare var VideoPlaybackQuality: {
-    readonly prototype: VideoPlaybackQuality;
+    prototype: VideoPlaybackQuality;
     new(): VideoPlaybackQuality;
 };
 
@@ -14954,7 +14954,7 @@ interface VisualViewport extends EventTarget {
 }
 
 declare var VisualViewport: {
-    readonly prototype: VisualViewport;
+    prototype: VisualViewport;
     new(): VisualViewport;
 };
 
@@ -15100,7 +15100,7 @@ interface WaveShaperNode extends AudioNode {
 }
 
 declare var WaveShaperNode: {
-    readonly prototype: WaveShaperNode;
+    prototype: WaveShaperNode;
     new(context: BaseAudioContext, options?: WaveShaperOptions): WaveShaperNode;
 };
 
@@ -15108,7 +15108,7 @@ interface WebGL2RenderingContext extends WebGL2RenderingContextBase, WebGL2Rende
 }
 
 declare var WebGL2RenderingContext: {
-    readonly prototype: WebGL2RenderingContext;
+    prototype: WebGL2RenderingContext;
     new(): WebGL2RenderingContext;
     readonly ACTIVE_UNIFORM_BLOCKS: GLenum;
     readonly ALREADY_SIGNALED: GLenum;
@@ -16076,7 +16076,7 @@ interface WebGLActiveInfo {
 }
 
 declare var WebGLActiveInfo: {
-    readonly prototype: WebGLActiveInfo;
+    prototype: WebGLActiveInfo;
     new(): WebGLActiveInfo;
 };
 
@@ -16085,7 +16085,7 @@ interface WebGLBuffer {
 }
 
 declare var WebGLBuffer: {
-    readonly prototype: WebGLBuffer;
+    prototype: WebGLBuffer;
     new(): WebGLBuffer;
 };
 
@@ -16095,7 +16095,7 @@ interface WebGLContextEvent extends Event {
 }
 
 declare var WebGLContextEvent: {
-    readonly prototype: WebGLContextEvent;
+    prototype: WebGLContextEvent;
     new(type: string, eventInit?: WebGLContextEventInit): WebGLContextEvent;
 };
 
@@ -16104,7 +16104,7 @@ interface WebGLFramebuffer {
 }
 
 declare var WebGLFramebuffer: {
-    readonly prototype: WebGLFramebuffer;
+    prototype: WebGLFramebuffer;
     new(): WebGLFramebuffer;
 };
 
@@ -16113,7 +16113,7 @@ interface WebGLProgram {
 }
 
 declare var WebGLProgram: {
-    readonly prototype: WebGLProgram;
+    prototype: WebGLProgram;
     new(): WebGLProgram;
 };
 
@@ -16121,7 +16121,7 @@ interface WebGLQuery {
 }
 
 declare var WebGLQuery: {
-    readonly prototype: WebGLQuery;
+    prototype: WebGLQuery;
     new(): WebGLQuery;
 };
 
@@ -16130,7 +16130,7 @@ interface WebGLRenderbuffer {
 }
 
 declare var WebGLRenderbuffer: {
-    readonly prototype: WebGLRenderbuffer;
+    prototype: WebGLRenderbuffer;
     new(): WebGLRenderbuffer;
 };
 
@@ -16139,7 +16139,7 @@ interface WebGLRenderingContext extends WebGLRenderingContextBase, WebGLRenderin
 }
 
 declare var WebGLRenderingContext: {
-    readonly prototype: WebGLRenderingContext;
+    prototype: WebGLRenderingContext;
     new(): WebGLRenderingContext;
     readonly ACTIVE_ATTRIBUTES: GLenum;
     readonly ACTIVE_TEXTURE: GLenum;
@@ -16916,7 +16916,7 @@ interface WebGLSampler {
 }
 
 declare var WebGLSampler: {
-    readonly prototype: WebGLSampler;
+    prototype: WebGLSampler;
     new(): WebGLSampler;
 };
 
@@ -16925,7 +16925,7 @@ interface WebGLShader {
 }
 
 declare var WebGLShader: {
-    readonly prototype: WebGLShader;
+    prototype: WebGLShader;
     new(): WebGLShader;
 };
 
@@ -16937,7 +16937,7 @@ interface WebGLShaderPrecisionFormat {
 }
 
 declare var WebGLShaderPrecisionFormat: {
-    readonly prototype: WebGLShaderPrecisionFormat;
+    prototype: WebGLShaderPrecisionFormat;
     new(): WebGLShaderPrecisionFormat;
 };
 
@@ -16945,7 +16945,7 @@ interface WebGLSync {
 }
 
 declare var WebGLSync: {
-    readonly prototype: WebGLSync;
+    prototype: WebGLSync;
     new(): WebGLSync;
 };
 
@@ -16954,7 +16954,7 @@ interface WebGLTexture {
 }
 
 declare var WebGLTexture: {
-    readonly prototype: WebGLTexture;
+    prototype: WebGLTexture;
     new(): WebGLTexture;
 };
 
@@ -16962,7 +16962,7 @@ interface WebGLTransformFeedback {
 }
 
 declare var WebGLTransformFeedback: {
-    readonly prototype: WebGLTransformFeedback;
+    prototype: WebGLTransformFeedback;
     new(): WebGLTransformFeedback;
 };
 
@@ -16971,7 +16971,7 @@ interface WebGLUniformLocation {
 }
 
 declare var WebGLUniformLocation: {
-    readonly prototype: WebGLUniformLocation;
+    prototype: WebGLUniformLocation;
     new(): WebGLUniformLocation;
 };
 
@@ -16979,7 +16979,7 @@ interface WebGLVertexArrayObject {
 }
 
 declare var WebGLVertexArrayObject: {
-    readonly prototype: WebGLVertexArrayObject;
+    prototype: WebGLVertexArrayObject;
     new(): WebGLVertexArrayObject;
 };
 
@@ -17046,7 +17046,7 @@ interface WebSocket extends EventTarget {
 }
 
 declare var WebSocket: {
-    readonly prototype: WebSocket;
+    prototype: WebSocket;
     new(url: string | URL, protocols?: string | string[]): WebSocket;
     readonly CLOSED: number;
     readonly CLOSING: number;
@@ -17066,7 +17066,7 @@ interface WheelEvent extends MouseEvent {
 }
 
 declare var WheelEvent: {
-    readonly prototype: WheelEvent;
+    prototype: WheelEvent;
     new(type: string, eventInitDict?: WheelEventInit): WheelEvent;
     readonly DOM_DELTA_LINE: number;
     readonly DOM_DELTA_PAGE: number;
@@ -17216,7 +17216,7 @@ interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandler
 }
 
 declare var Window: {
-    readonly prototype: Window;
+    prototype: Window;
     new(): Window;
 };
 
@@ -17319,7 +17319,7 @@ interface Worker extends EventTarget, AbstractWorker {
 }
 
 declare var Worker: {
-    readonly prototype: Worker;
+    prototype: Worker;
     new(scriptURL: string | URL, options?: WorkerOptions): Worker;
 };
 
@@ -17335,7 +17335,7 @@ interface Worklet {
 }
 
 declare var Worklet: {
-    readonly prototype: Worklet;
+    prototype: Worklet;
     new(): Worklet;
 };
 
@@ -17348,7 +17348,7 @@ interface WritableStream<W = any> {
 }
 
 declare var WritableStream: {
-    readonly prototype: WritableStream;
+    prototype: WritableStream;
     new<W = any>(underlyingSink?: UnderlyingSink<W>, strategy?: QueuingStrategy<W>): WritableStream<W>;
 };
 
@@ -17358,7 +17358,7 @@ interface WritableStreamDefaultController {
 }
 
 declare var WritableStreamDefaultController: {
-    readonly prototype: WritableStreamDefaultController;
+    prototype: WritableStreamDefaultController;
     new(): WritableStreamDefaultController;
 };
 
@@ -17374,7 +17374,7 @@ interface WritableStreamDefaultWriter<W = any> {
 }
 
 declare var WritableStreamDefaultWriter: {
-    readonly prototype: WritableStreamDefaultWriter;
+    prototype: WritableStreamDefaultWriter;
     new<W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>;
 };
 
@@ -17387,7 +17387,7 @@ interface XMLDocument extends Document {
 }
 
 declare var XMLDocument: {
-    readonly prototype: XMLDocument;
+    prototype: XMLDocument;
     new(): XMLDocument;
 };
 
@@ -17498,7 +17498,7 @@ interface XMLHttpRequest extends XMLHttpRequestEventTarget {
 }
 
 declare var XMLHttpRequest: {
-    readonly prototype: XMLHttpRequest;
+    prototype: XMLHttpRequest;
     new(): XMLHttpRequest;
     readonly DONE: number;
     readonly HEADERS_RECEIVED: number;
@@ -17532,7 +17532,7 @@ interface XMLHttpRequestEventTarget extends EventTarget {
 }
 
 declare var XMLHttpRequestEventTarget: {
-    readonly prototype: XMLHttpRequestEventTarget;
+    prototype: XMLHttpRequestEventTarget;
     new(): XMLHttpRequestEventTarget;
 };
 
@@ -17544,7 +17544,7 @@ interface XMLHttpRequestUpload extends XMLHttpRequestEventTarget {
 }
 
 declare var XMLHttpRequestUpload: {
-    readonly prototype: XMLHttpRequestUpload;
+    prototype: XMLHttpRequestUpload;
     new(): XMLHttpRequestUpload;
 };
 
@@ -17554,7 +17554,7 @@ interface XMLSerializer {
 }
 
 declare var XMLSerializer: {
-    readonly prototype: XMLSerializer;
+    prototype: XMLSerializer;
     new(): XMLSerializer;
 };
 
@@ -17563,7 +17563,7 @@ interface XPathEvaluator extends XPathEvaluatorBase {
 }
 
 declare var XPathEvaluator: {
-    readonly prototype: XPathEvaluator;
+    prototype: XPathEvaluator;
     new(): XPathEvaluator;
 };
 
@@ -17579,7 +17579,7 @@ interface XPathExpression {
 }
 
 declare var XPathExpression: {
-    readonly prototype: XPathExpression;
+    prototype: XPathExpression;
     new(): XPathExpression;
 };
 
@@ -17607,7 +17607,7 @@ interface XPathResult {
 }
 
 declare var XPathResult: {
-    readonly prototype: XPathResult;
+    prototype: XPathResult;
     new(): XPathResult;
     readonly ANY_TYPE: number;
     readonly ANY_UNORDERED_NODE_TYPE: number;
@@ -17634,7 +17634,7 @@ interface XSLTProcessor {
 }
 
 declare var XSLTProcessor: {
-    readonly prototype: XSLTProcessor;
+    prototype: XSLTProcessor;
     new(): XSLTProcessor;
 };
 
@@ -17675,7 +17675,7 @@ declare namespace WebAssembly {
     }
 
     var CompileError: {
-        readonly prototype: CompileError;
+        prototype: CompileError;
         new(): CompileError;
     };
 
@@ -17685,7 +17685,7 @@ declare namespace WebAssembly {
     }
 
     var Global: {
-        readonly prototype: Global;
+        prototype: Global;
         new(descriptor: GlobalDescriptor, v?: any): Global;
     };
 
@@ -17694,7 +17694,7 @@ declare namespace WebAssembly {
     }
 
     var Instance: {
-        readonly prototype: Instance;
+        prototype: Instance;
         new(module: Module, importObject?: Imports): Instance;
     };
 
@@ -17702,7 +17702,7 @@ declare namespace WebAssembly {
     }
 
     var LinkError: {
-        readonly prototype: LinkError;
+        prototype: LinkError;
         new(): LinkError;
     };
 
@@ -17712,7 +17712,7 @@ declare namespace WebAssembly {
     }
 
     var Memory: {
-        readonly prototype: Memory;
+        prototype: Memory;
         new(descriptor: MemoryDescriptor): Memory;
     };
 
@@ -17720,7 +17720,7 @@ declare namespace WebAssembly {
     }
 
     var Module: {
-        readonly prototype: Module;
+        prototype: Module;
         new(bytes: BufferSource): Module;
         customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
         exports(moduleObject: Module): ModuleExportDescriptor[];
@@ -17731,7 +17731,7 @@ declare namespace WebAssembly {
     }
 
     var RuntimeError: {
-        readonly prototype: RuntimeError;
+        prototype: RuntimeError;
         new(): RuntimeError;
     };
 
@@ -17743,7 +17743,7 @@ declare namespace WebAssembly {
     }
 
     var Table: {
-        readonly prototype: Table;
+        prototype: Table;
         new(descriptor: TableDescriptor, value?: any): Table;
     };
 

--- a/baselines/serviceworker.generated.d.ts
+++ b/baselines/serviceworker.generated.d.ts
@@ -684,7 +684,7 @@ interface AbortController {
 }
 
 declare var AbortController: {
-    readonly prototype: AbortController;
+    prototype: AbortController;
     new(): AbortController;
 };
 
@@ -706,7 +706,7 @@ interface AbortSignal extends EventTarget {
 }
 
 declare var AbortSignal: {
-    readonly prototype: AbortSignal;
+    prototype: AbortSignal;
     new(): AbortSignal;
 };
 
@@ -733,7 +733,7 @@ interface Blob {
 }
 
 declare var Blob: {
-    readonly prototype: Blob;
+    prototype: Blob;
     new(blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
 };
 
@@ -774,7 +774,7 @@ interface BroadcastChannel extends EventTarget {
 }
 
 declare var BroadcastChannel: {
-    readonly prototype: BroadcastChannel;
+    prototype: BroadcastChannel;
     new(name: string): BroadcastChannel;
 };
 
@@ -785,7 +785,7 @@ interface ByteLengthQueuingStrategy extends QueuingStrategy<ArrayBufferView> {
 }
 
 declare var ByteLengthQueuingStrategy: {
-    readonly prototype: ByteLengthQueuingStrategy;
+    prototype: ByteLengthQueuingStrategy;
     new(init: QueuingStrategyInit): ByteLengthQueuingStrategy;
 };
 
@@ -801,7 +801,7 @@ interface Cache {
 }
 
 declare var Cache: {
-    readonly prototype: Cache;
+    prototype: Cache;
     new(): Cache;
 };
 
@@ -815,7 +815,7 @@ interface CacheStorage {
 }
 
 declare var CacheStorage: {
-    readonly prototype: CacheStorage;
+    prototype: CacheStorage;
     new(): CacheStorage;
 };
 
@@ -830,7 +830,7 @@ interface CanvasGradient {
 }
 
 declare var CanvasGradient: {
-    readonly prototype: CanvasGradient;
+    prototype: CanvasGradient;
     new(): CanvasGradient;
 };
 
@@ -855,7 +855,7 @@ interface CanvasPattern {
 }
 
 declare var CanvasPattern: {
-    readonly prototype: CanvasPattern;
+    prototype: CanvasPattern;
     new(): CanvasPattern;
 };
 
@@ -870,7 +870,7 @@ interface Client {
 }
 
 declare var Client: {
-    readonly prototype: Client;
+    prototype: Client;
     new(): Client;
 };
 
@@ -883,7 +883,7 @@ interface Clients {
 }
 
 declare var Clients: {
-    readonly prototype: Clients;
+    prototype: Clients;
     new(): Clients;
 };
 
@@ -904,7 +904,7 @@ interface CloseEvent extends Event {
 }
 
 declare var CloseEvent: {
-    readonly prototype: CloseEvent;
+    prototype: CloseEvent;
     new(type: string, eventInitDict?: CloseEventInit): CloseEvent;
 };
 
@@ -915,7 +915,7 @@ interface CountQueuingStrategy extends QueuingStrategy {
 }
 
 declare var CountQueuingStrategy: {
-    readonly prototype: CountQueuingStrategy;
+    prototype: CountQueuingStrategy;
     new(init: QueuingStrategyInit): CountQueuingStrategy;
 };
 
@@ -926,7 +926,7 @@ interface Crypto {
 }
 
 declare var Crypto: {
-    readonly prototype: Crypto;
+    prototype: Crypto;
     new(): Crypto;
 };
 
@@ -939,7 +939,7 @@ interface CryptoKey {
 }
 
 declare var CryptoKey: {
-    readonly prototype: CryptoKey;
+    prototype: CryptoKey;
     new(): CryptoKey;
 };
 
@@ -953,7 +953,7 @@ interface CustomEvent<T = any> extends Event {
 }
 
 declare var CustomEvent: {
-    readonly prototype: CustomEvent;
+    prototype: CustomEvent;
     new<T>(type: string, eventInitDict?: CustomEventInit<T>): CustomEvent<T>;
 };
 
@@ -990,7 +990,7 @@ interface DOMException {
 }
 
 declare var DOMException: {
-    readonly prototype: DOMException;
+    prototype: DOMException;
     new(message?: string, name?: string): DOMException;
     readonly ABORT_ERR: number;
     readonly DATA_CLONE_ERR: number;
@@ -1034,7 +1034,7 @@ interface DOMMatrix extends DOMMatrixReadOnly {
 }
 
 declare var DOMMatrix: {
-    readonly prototype: DOMMatrix;
+    prototype: DOMMatrix;
     new(init?: string | number[]): DOMMatrix;
     fromFloat32Array(array32: Float32Array): DOMMatrix;
     fromFloat64Array(array64: Float64Array): DOMMatrix;
@@ -1087,7 +1087,7 @@ interface DOMMatrixReadOnly {
 }
 
 declare var DOMMatrixReadOnly: {
-    readonly prototype: DOMMatrixReadOnly;
+    prototype: DOMMatrixReadOnly;
     new(init?: string | number[]): DOMMatrixReadOnly;
     fromFloat32Array(array32: Float32Array): DOMMatrixReadOnly;
     fromFloat64Array(array64: Float64Array): DOMMatrixReadOnly;
@@ -1098,7 +1098,7 @@ interface DOMPoint extends DOMPointReadOnly {
 }
 
 declare var DOMPoint: {
-    readonly prototype: DOMPoint;
+    prototype: DOMPoint;
     new(x?: number, y?: number, z?: number, w?: number): DOMPoint;
     fromPoint(other?: DOMPointInit): DOMPoint;
 };
@@ -1113,7 +1113,7 @@ interface DOMPointReadOnly {
 }
 
 declare var DOMPointReadOnly: {
-    readonly prototype: DOMPointReadOnly;
+    prototype: DOMPointReadOnly;
     new(x?: number, y?: number, z?: number, w?: number): DOMPointReadOnly;
     fromPoint(other?: DOMPointInit): DOMPointReadOnly;
 };
@@ -1128,7 +1128,7 @@ interface DOMQuad {
 }
 
 declare var DOMQuad: {
-    readonly prototype: DOMQuad;
+    prototype: DOMQuad;
     new(p1?: DOMPointInit, p2?: DOMPointInit, p3?: DOMPointInit, p4?: DOMPointInit): DOMQuad;
     fromQuad(other?: DOMQuadInit): DOMQuad;
     fromRect(other?: DOMRectInit): DOMQuad;
@@ -1138,7 +1138,7 @@ interface DOMRect extends DOMRectReadOnly {
 }
 
 declare var DOMRect: {
-    readonly prototype: DOMRect;
+    prototype: DOMRect;
     new(x?: number, y?: number, width?: number, height?: number): DOMRect;
     fromRect(other?: DOMRectInit): DOMRect;
 };
@@ -1156,7 +1156,7 @@ interface DOMRectReadOnly {
 }
 
 declare var DOMRectReadOnly: {
-    readonly prototype: DOMRectReadOnly;
+    prototype: DOMRectReadOnly;
     new(x?: number, y?: number, width?: number, height?: number): DOMRectReadOnly;
     fromRect(other?: DOMRectInit): DOMRectReadOnly;
 };
@@ -1179,7 +1179,7 @@ interface DOMStringList {
 }
 
 declare var DOMStringList: {
-    readonly prototype: DOMStringList;
+    prototype: DOMStringList;
     new(): DOMStringList;
 };
 
@@ -1238,7 +1238,7 @@ interface ErrorEvent extends Event {
 }
 
 declare var ErrorEvent: {
-    readonly prototype: ErrorEvent;
+    prototype: ErrorEvent;
     new(type: string, eventInitDict?: ErrorEventInit): ErrorEvent;
 };
 
@@ -1314,7 +1314,7 @@ interface Event {
 }
 
 declare var Event: {
-    readonly prototype: Event;
+    prototype: Event;
     new(type: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
@@ -1358,7 +1358,7 @@ interface EventSource extends EventTarget {
 }
 
 declare var EventSource: {
-    readonly prototype: EventSource;
+    prototype: EventSource;
     new(url: string | URL, eventSourceInitDict?: EventSourceInit): EventSource;
     readonly CLOSED: number;
     readonly CONNECTING: number;
@@ -1394,7 +1394,7 @@ interface EventTarget {
 }
 
 declare var EventTarget: {
-    readonly prototype: EventTarget;
+    prototype: EventTarget;
     new(): EventTarget;
 };
 
@@ -1404,7 +1404,7 @@ interface ExtendableEvent extends Event {
 }
 
 declare var ExtendableEvent: {
-    readonly prototype: ExtendableEvent;
+    prototype: ExtendableEvent;
     new(type: string, eventInitDict?: ExtendableEventInit): ExtendableEvent;
 };
 
@@ -1418,7 +1418,7 @@ interface ExtendableMessageEvent extends ExtendableEvent {
 }
 
 declare var ExtendableMessageEvent: {
-    readonly prototype: ExtendableMessageEvent;
+    prototype: ExtendableMessageEvent;
     new(type: string, eventInitDict?: ExtendableMessageEventInit): ExtendableMessageEvent;
 };
 
@@ -1431,7 +1431,7 @@ interface FetchEvent extends ExtendableEvent {
 }
 
 declare var FetchEvent: {
-    readonly prototype: FetchEvent;
+    prototype: FetchEvent;
     new(type: string, eventInitDict: FetchEventInit): FetchEvent;
 };
 
@@ -1443,7 +1443,7 @@ interface File extends Blob {
 }
 
 declare var File: {
-    readonly prototype: File;
+    prototype: File;
     new(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File;
 };
 
@@ -1455,7 +1455,7 @@ interface FileList {
 }
 
 declare var FileList: {
-    readonly prototype: FileList;
+    prototype: FileList;
     new(): FileList;
 };
 
@@ -1494,7 +1494,7 @@ interface FileReader extends EventTarget {
 }
 
 declare var FileReader: {
-    readonly prototype: FileReader;
+    prototype: FileReader;
     new(): FileReader;
     readonly DONE: number;
     readonly EMPTY: number;
@@ -1520,7 +1520,7 @@ interface FontFace {
 }
 
 declare var FontFace: {
-    readonly prototype: FontFace;
+    prototype: FontFace;
     new(family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors): FontFace;
 };
 
@@ -1546,7 +1546,7 @@ interface FontFaceSet extends EventTarget {
 }
 
 declare var FontFaceSet: {
-    readonly prototype: FontFaceSet;
+    prototype: FontFaceSet;
     new(initialFaces: FontFace[]): FontFaceSet;
 };
 
@@ -1555,7 +1555,7 @@ interface FontFaceSetLoadEvent extends Event {
 }
 
 declare var FontFaceSetLoadEvent: {
-    readonly prototype: FontFaceSetLoadEvent;
+    prototype: FontFaceSetLoadEvent;
     new(type: string, eventInitDict?: FontFaceSetLoadEventInit): FontFaceSetLoadEvent;
 };
 
@@ -1575,7 +1575,7 @@ interface FormData {
 }
 
 declare var FormData: {
-    readonly prototype: FormData;
+    prototype: FormData;
     new(): FormData;
 };
 
@@ -1595,7 +1595,7 @@ interface Headers {
 }
 
 declare var Headers: {
-    readonly prototype: Headers;
+    prototype: Headers;
     new(init?: HeadersInit): Headers;
 };
 
@@ -1647,7 +1647,7 @@ interface IDBCursor {
 }
 
 declare var IDBCursor: {
-    readonly prototype: IDBCursor;
+    prototype: IDBCursor;
     new(): IDBCursor;
 };
 
@@ -1660,7 +1660,7 @@ interface IDBCursorWithValue extends IDBCursor {
 }
 
 declare var IDBCursorWithValue: {
-    readonly prototype: IDBCursorWithValue;
+    prototype: IDBCursorWithValue;
     new(): IDBCursorWithValue;
 };
 
@@ -1716,7 +1716,7 @@ interface IDBDatabase extends EventTarget {
 }
 
 declare var IDBDatabase: {
-    readonly prototype: IDBDatabase;
+    prototype: IDBDatabase;
     new(): IDBDatabase;
 };
 
@@ -1740,7 +1740,7 @@ interface IDBFactory {
 }
 
 declare var IDBFactory: {
-    readonly prototype: IDBFactory;
+    prototype: IDBFactory;
     new(): IDBFactory;
 };
 
@@ -1802,7 +1802,7 @@ interface IDBIndex {
 }
 
 declare var IDBIndex: {
-    readonly prototype: IDBIndex;
+    prototype: IDBIndex;
     new(): IDBIndex;
 };
 
@@ -1831,7 +1831,7 @@ interface IDBKeyRange {
 }
 
 declare var IDBKeyRange: {
-    readonly prototype: IDBKeyRange;
+    prototype: IDBKeyRange;
     new(): IDBKeyRange;
     /**
      * Returns a new IDBKeyRange spanning from lower to upper. If lowerOpen is true, lower is not included in the range. If upperOpen is true, upper is not included in the range.
@@ -1963,7 +1963,7 @@ interface IDBObjectStore {
 }
 
 declare var IDBObjectStore: {
-    readonly prototype: IDBObjectStore;
+    prototype: IDBObjectStore;
     new(): IDBObjectStore;
 };
 
@@ -1983,7 +1983,7 @@ interface IDBOpenDBRequest extends IDBRequest<IDBDatabase> {
 }
 
 declare var IDBOpenDBRequest: {
-    readonly prototype: IDBOpenDBRequest;
+    prototype: IDBOpenDBRequest;
     new(): IDBOpenDBRequest;
 };
 
@@ -2023,7 +2023,7 @@ interface IDBRequest<T = any> extends EventTarget {
 }
 
 declare var IDBRequest: {
-    readonly prototype: IDBRequest;
+    prototype: IDBRequest;
     new(): IDBRequest;
 };
 
@@ -2069,7 +2069,7 @@ interface IDBTransaction extends EventTarget {
 }
 
 declare var IDBTransaction: {
-    readonly prototype: IDBTransaction;
+    prototype: IDBTransaction;
     new(): IDBTransaction;
 };
 
@@ -2080,7 +2080,7 @@ interface IDBVersionChangeEvent extends Event {
 }
 
 declare var IDBVersionChangeEvent: {
-    readonly prototype: IDBVersionChangeEvent;
+    prototype: IDBVersionChangeEvent;
     new(type: string, eventInitDict?: IDBVersionChangeEventInit): IDBVersionChangeEvent;
 };
 
@@ -2100,7 +2100,7 @@ interface ImageBitmap {
 }
 
 declare var ImageBitmap: {
-    readonly prototype: ImageBitmap;
+    prototype: ImageBitmap;
     new(): ImageBitmap;
 };
 
@@ -2112,7 +2112,7 @@ interface ImageBitmapRenderingContext {
 }
 
 declare var ImageBitmapRenderingContext: {
-    readonly prototype: ImageBitmapRenderingContext;
+    prototype: ImageBitmapRenderingContext;
     new(): ImageBitmapRenderingContext;
 };
 
@@ -2133,7 +2133,7 @@ interface ImageData {
 }
 
 declare var ImageData: {
-    readonly prototype: ImageData;
+    prototype: ImageData;
     new(sw: number, sh: number, settings?: ImageDataSettings): ImageData;
     new(data: Uint8ClampedArray, sw: number, sh?: number, settings?: ImageDataSettings): ImageData;
 };
@@ -2148,7 +2148,7 @@ interface MediaCapabilities {
 }
 
 declare var MediaCapabilities: {
-    readonly prototype: MediaCapabilities;
+    prototype: MediaCapabilities;
     new(): MediaCapabilities;
 };
 
@@ -2165,7 +2165,7 @@ interface MessageChannel {
 }
 
 declare var MessageChannel: {
-    readonly prototype: MessageChannel;
+    prototype: MessageChannel;
     new(): MessageChannel;
 };
 
@@ -2196,7 +2196,7 @@ interface MessageEvent<T = any> extends Event {
 }
 
 declare var MessageEvent: {
-    readonly prototype: MessageEvent;
+    prototype: MessageEvent;
     new<T>(type: string, eventInitDict?: MessageEventInit<T>): MessageEvent<T>;
 };
 
@@ -2231,7 +2231,7 @@ interface MessagePort extends EventTarget {
 }
 
 declare var MessagePort: {
-    readonly prototype: MessagePort;
+    prototype: MessagePort;
     new(): MessagePort;
 };
 
@@ -2275,7 +2275,7 @@ interface NetworkInformation extends EventTarget {
 }
 
 declare var NetworkInformation: {
-    readonly prototype: NetworkInformation;
+    prototype: NetworkInformation;
     new(): NetworkInformation;
 };
 
@@ -2307,7 +2307,7 @@ interface Notification extends EventTarget {
 }
 
 declare var Notification: {
-    readonly prototype: Notification;
+    prototype: Notification;
     new(title: string, options?: NotificationOptions): Notification;
     readonly permission: NotificationPermission;
 };
@@ -2319,7 +2319,7 @@ interface NotificationEvent extends ExtendableEvent {
 }
 
 declare var NotificationEvent: {
-    readonly prototype: NotificationEvent;
+    prototype: NotificationEvent;
     new(type: string, eventInitDict: NotificationEventInit): NotificationEvent;
 };
 
@@ -2377,7 +2377,7 @@ interface Path2D extends CanvasPath {
 }
 
 declare var Path2D: {
-    readonly prototype: Path2D;
+    prototype: Path2D;
     new(path?: Path2D | string): Path2D;
 };
 
@@ -2407,7 +2407,7 @@ interface Performance extends EventTarget {
 }
 
 declare var Performance: {
-    readonly prototype: Performance;
+    prototype: Performance;
     new(): Performance;
 };
 
@@ -2421,7 +2421,7 @@ interface PerformanceEntry {
 }
 
 declare var PerformanceEntry: {
-    readonly prototype: PerformanceEntry;
+    prototype: PerformanceEntry;
     new(): PerformanceEntry;
 };
 
@@ -2431,7 +2431,7 @@ interface PerformanceMark extends PerformanceEntry {
 }
 
 declare var PerformanceMark: {
-    readonly prototype: PerformanceMark;
+    prototype: PerformanceMark;
     new(markName: string, markOptions?: PerformanceMarkOptions): PerformanceMark;
 };
 
@@ -2441,7 +2441,7 @@ interface PerformanceMeasure extends PerformanceEntry {
 }
 
 declare var PerformanceMeasure: {
-    readonly prototype: PerformanceMeasure;
+    prototype: PerformanceMeasure;
     new(): PerformanceMeasure;
 };
 
@@ -2452,7 +2452,7 @@ interface PerformanceObserver {
 }
 
 declare var PerformanceObserver: {
-    readonly prototype: PerformanceObserver;
+    prototype: PerformanceObserver;
     new(callback: PerformanceObserverCallback): PerformanceObserver;
     readonly supportedEntryTypes: ReadonlyArray<string>;
 };
@@ -2464,7 +2464,7 @@ interface PerformanceObserverEntryList {
 }
 
 declare var PerformanceObserverEntryList: {
-    readonly prototype: PerformanceObserverEntryList;
+    prototype: PerformanceObserverEntryList;
     new(): PerformanceObserverEntryList;
 };
 
@@ -2492,7 +2492,7 @@ interface PerformanceResourceTiming extends PerformanceEntry {
 }
 
 declare var PerformanceResourceTiming: {
-    readonly prototype: PerformanceResourceTiming;
+    prototype: PerformanceResourceTiming;
     new(): PerformanceResourceTiming;
 };
 
@@ -2504,7 +2504,7 @@ interface PerformanceServerTiming {
 }
 
 declare var PerformanceServerTiming: {
-    readonly prototype: PerformanceServerTiming;
+    prototype: PerformanceServerTiming;
     new(): PerformanceServerTiming;
 };
 
@@ -2522,7 +2522,7 @@ interface PermissionStatus extends EventTarget {
 }
 
 declare var PermissionStatus: {
-    readonly prototype: PermissionStatus;
+    prototype: PermissionStatus;
     new(): PermissionStatus;
 };
 
@@ -2531,7 +2531,7 @@ interface Permissions {
 }
 
 declare var Permissions: {
-    readonly prototype: Permissions;
+    prototype: Permissions;
     new(): Permissions;
 };
 
@@ -2544,7 +2544,7 @@ interface ProgressEvent<T extends EventTarget = EventTarget> extends Event {
 }
 
 declare var ProgressEvent: {
-    readonly prototype: ProgressEvent;
+    prototype: ProgressEvent;
     new(type: string, eventInitDict?: ProgressEventInit): ProgressEvent;
 };
 
@@ -2554,7 +2554,7 @@ interface PromiseRejectionEvent extends Event {
 }
 
 declare var PromiseRejectionEvent: {
-    readonly prototype: PromiseRejectionEvent;
+    prototype: PromiseRejectionEvent;
     new(type: string, eventInitDict: PromiseRejectionEventInit): PromiseRejectionEvent;
 };
 
@@ -2564,7 +2564,7 @@ interface PushEvent extends ExtendableEvent {
 }
 
 declare var PushEvent: {
-    readonly prototype: PushEvent;
+    prototype: PushEvent;
     new(type: string, eventInitDict?: PushEventInit): PushEvent;
 };
 
@@ -2576,7 +2576,7 @@ interface PushManager {
 }
 
 declare var PushManager: {
-    readonly prototype: PushManager;
+    prototype: PushManager;
     new(): PushManager;
     readonly supportedContentEncodings: ReadonlyArray<string>;
 };
@@ -2590,7 +2590,7 @@ interface PushMessageData {
 }
 
 declare var PushMessageData: {
-    readonly prototype: PushMessageData;
+    prototype: PushMessageData;
     new(): PushMessageData;
 };
 
@@ -2604,7 +2604,7 @@ interface PushSubscription {
 }
 
 declare var PushSubscription: {
-    readonly prototype: PushSubscription;
+    prototype: PushSubscription;
     new(): PushSubscription;
 };
 
@@ -2613,7 +2613,7 @@ interface PushSubscriptionOptions {
 }
 
 declare var PushSubscriptionOptions: {
-    readonly prototype: PushSubscriptionOptions;
+    prototype: PushSubscriptionOptions;
     new(): PushSubscriptionOptions;
 };
 
@@ -2629,7 +2629,7 @@ interface ReadableStream<R = any> {
 }
 
 declare var ReadableStream: {
-    readonly prototype: ReadableStream;
+    prototype: ReadableStream;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 
@@ -2641,7 +2641,7 @@ interface ReadableStreamDefaultController<R = any> {
 }
 
 declare var ReadableStreamDefaultController: {
-    readonly prototype: ReadableStreamDefaultController;
+    prototype: ReadableStreamDefaultController;
     new(): ReadableStreamDefaultController;
 };
 
@@ -2651,7 +2651,7 @@ interface ReadableStreamDefaultReader<R = any> extends ReadableStreamGenericRead
 }
 
 declare var ReadableStreamDefaultReader: {
-    readonly prototype: ReadableStreamDefaultReader;
+    prototype: ReadableStreamDefaultReader;
     new<R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>;
 };
 
@@ -2718,7 +2718,7 @@ interface Request extends Body {
 }
 
 declare var Request: {
-    readonly prototype: Request;
+    prototype: Request;
     new(input: RequestInfo, init?: RequestInit): Request;
 };
 
@@ -2735,7 +2735,7 @@ interface Response extends Body {
 }
 
 declare var Response: {
-    readonly prototype: Response;
+    prototype: Response;
     new(body?: BodyInit | null, init?: ResponseInit): Response;
     error(): Response;
     redirect(url: string | URL, status?: number): Response;
@@ -2758,7 +2758,7 @@ interface SecurityPolicyViolationEvent extends Event {
 }
 
 declare var SecurityPolicyViolationEvent: {
-    readonly prototype: SecurityPolicyViolationEvent;
+    prototype: SecurityPolicyViolationEvent;
     new(type: string, eventInitDict?: SecurityPolicyViolationEventInit): SecurityPolicyViolationEvent;
 };
 
@@ -2780,7 +2780,7 @@ interface ServiceWorker extends EventTarget, AbstractWorker {
 }
 
 declare var ServiceWorker: {
-    readonly prototype: ServiceWorker;
+    prototype: ServiceWorker;
     new(): ServiceWorker;
 };
 
@@ -2808,7 +2808,7 @@ interface ServiceWorkerContainer extends EventTarget {
 }
 
 declare var ServiceWorkerContainer: {
-    readonly prototype: ServiceWorkerContainer;
+    prototype: ServiceWorkerContainer;
     new(): ServiceWorkerContainer;
 };
 
@@ -2843,7 +2843,7 @@ interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
 }
 
 declare var ServiceWorkerGlobalScope: {
-    readonly prototype: ServiceWorkerGlobalScope;
+    prototype: ServiceWorkerGlobalScope;
     new(): ServiceWorkerGlobalScope;
 };
 
@@ -2871,7 +2871,7 @@ interface ServiceWorkerRegistration extends EventTarget {
 }
 
 declare var ServiceWorkerRegistration: {
-    readonly prototype: ServiceWorkerRegistration;
+    prototype: ServiceWorkerRegistration;
     new(): ServiceWorkerRegistration;
 };
 
@@ -2881,7 +2881,7 @@ interface StorageManager {
 }
 
 declare var StorageManager: {
-    readonly prototype: StorageManager;
+    prototype: StorageManager;
     new(): StorageManager;
 };
 
@@ -2906,7 +2906,7 @@ interface SubtleCrypto {
 }
 
 declare var SubtleCrypto: {
-    readonly prototype: SubtleCrypto;
+    prototype: SubtleCrypto;
     new(): SubtleCrypto;
 };
 
@@ -2929,7 +2929,7 @@ interface TextDecoder extends TextDecoderCommon {
 }
 
 declare var TextDecoder: {
-    readonly prototype: TextDecoder;
+    prototype: TextDecoder;
     new(label?: string, options?: TextDecoderOptions): TextDecoder;
 };
 
@@ -2954,7 +2954,7 @@ interface TextDecoderStream extends GenericTransformStream, TextDecoderCommon {
 }
 
 declare var TextDecoderStream: {
-    readonly prototype: TextDecoderStream;
+    prototype: TextDecoderStream;
     new(label?: string, options?: TextDecoderOptions): TextDecoderStream;
 };
 
@@ -2971,7 +2971,7 @@ interface TextEncoder extends TextEncoderCommon {
 }
 
 declare var TextEncoder: {
-    readonly prototype: TextEncoder;
+    prototype: TextEncoder;
     new(): TextEncoder;
 };
 
@@ -2988,7 +2988,7 @@ interface TextEncoderStream extends GenericTransformStream, TextEncoderCommon {
 }
 
 declare var TextEncoderStream: {
-    readonly prototype: TextEncoderStream;
+    prototype: TextEncoderStream;
     new(): TextEncoderStream;
 };
 
@@ -3025,7 +3025,7 @@ interface TextMetrics {
 }
 
 declare var TextMetrics: {
-    readonly prototype: TextMetrics;
+    prototype: TextMetrics;
     new(): TextMetrics;
 };
 
@@ -3035,7 +3035,7 @@ interface TransformStream<I = any, O = any> {
 }
 
 declare var TransformStream: {
-    readonly prototype: TransformStream;
+    prototype: TransformStream;
     new<I = any, O = any>(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>): TransformStream<I, O>;
 };
 
@@ -3047,7 +3047,7 @@ interface TransformStreamDefaultController<O = any> {
 }
 
 declare var TransformStreamDefaultController: {
-    readonly prototype: TransformStreamDefaultController;
+    prototype: TransformStreamDefaultController;
     new(): TransformStreamDefaultController;
 };
 
@@ -3070,7 +3070,7 @@ interface URL {
 }
 
 declare var URL: {
-    readonly prototype: URL;
+    prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
     createObjectURL(object: any): string;
 };
@@ -3109,7 +3109,7 @@ interface URLSearchParams {
 }
 
 declare var URLSearchParams: {
-    readonly prototype: URLSearchParams;
+    prototype: URLSearchParams;
     new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
     toString(): string;
 };
@@ -3253,7 +3253,7 @@ interface WebGL2RenderingContext extends WebGL2RenderingContextBase, WebGL2Rende
 }
 
 declare var WebGL2RenderingContext: {
-    readonly prototype: WebGL2RenderingContext;
+    prototype: WebGL2RenderingContext;
     new(): WebGL2RenderingContext;
     readonly ACTIVE_UNIFORM_BLOCKS: GLenum;
     readonly ALREADY_SIGNALED: GLenum;
@@ -4221,7 +4221,7 @@ interface WebGLActiveInfo {
 }
 
 declare var WebGLActiveInfo: {
-    readonly prototype: WebGLActiveInfo;
+    prototype: WebGLActiveInfo;
     new(): WebGLActiveInfo;
 };
 
@@ -4230,7 +4230,7 @@ interface WebGLBuffer {
 }
 
 declare var WebGLBuffer: {
-    readonly prototype: WebGLBuffer;
+    prototype: WebGLBuffer;
     new(): WebGLBuffer;
 };
 
@@ -4240,7 +4240,7 @@ interface WebGLContextEvent extends Event {
 }
 
 declare var WebGLContextEvent: {
-    readonly prototype: WebGLContextEvent;
+    prototype: WebGLContextEvent;
     new(type: string, eventInit?: WebGLContextEventInit): WebGLContextEvent;
 };
 
@@ -4249,7 +4249,7 @@ interface WebGLFramebuffer {
 }
 
 declare var WebGLFramebuffer: {
-    readonly prototype: WebGLFramebuffer;
+    prototype: WebGLFramebuffer;
     new(): WebGLFramebuffer;
 };
 
@@ -4258,7 +4258,7 @@ interface WebGLProgram {
 }
 
 declare var WebGLProgram: {
-    readonly prototype: WebGLProgram;
+    prototype: WebGLProgram;
     new(): WebGLProgram;
 };
 
@@ -4266,7 +4266,7 @@ interface WebGLQuery {
 }
 
 declare var WebGLQuery: {
-    readonly prototype: WebGLQuery;
+    prototype: WebGLQuery;
     new(): WebGLQuery;
 };
 
@@ -4275,7 +4275,7 @@ interface WebGLRenderbuffer {
 }
 
 declare var WebGLRenderbuffer: {
-    readonly prototype: WebGLRenderbuffer;
+    prototype: WebGLRenderbuffer;
     new(): WebGLRenderbuffer;
 };
 
@@ -4284,7 +4284,7 @@ interface WebGLRenderingContext extends WebGLRenderingContextBase, WebGLRenderin
 }
 
 declare var WebGLRenderingContext: {
-    readonly prototype: WebGLRenderingContext;
+    prototype: WebGLRenderingContext;
     new(): WebGLRenderingContext;
     readonly ACTIVE_ATTRIBUTES: GLenum;
     readonly ACTIVE_TEXTURE: GLenum;
@@ -5061,7 +5061,7 @@ interface WebGLSampler {
 }
 
 declare var WebGLSampler: {
-    readonly prototype: WebGLSampler;
+    prototype: WebGLSampler;
     new(): WebGLSampler;
 };
 
@@ -5070,7 +5070,7 @@ interface WebGLShader {
 }
 
 declare var WebGLShader: {
-    readonly prototype: WebGLShader;
+    prototype: WebGLShader;
     new(): WebGLShader;
 };
 
@@ -5082,7 +5082,7 @@ interface WebGLShaderPrecisionFormat {
 }
 
 declare var WebGLShaderPrecisionFormat: {
-    readonly prototype: WebGLShaderPrecisionFormat;
+    prototype: WebGLShaderPrecisionFormat;
     new(): WebGLShaderPrecisionFormat;
 };
 
@@ -5090,7 +5090,7 @@ interface WebGLSync {
 }
 
 declare var WebGLSync: {
-    readonly prototype: WebGLSync;
+    prototype: WebGLSync;
     new(): WebGLSync;
 };
 
@@ -5099,7 +5099,7 @@ interface WebGLTexture {
 }
 
 declare var WebGLTexture: {
-    readonly prototype: WebGLTexture;
+    prototype: WebGLTexture;
     new(): WebGLTexture;
 };
 
@@ -5107,7 +5107,7 @@ interface WebGLTransformFeedback {
 }
 
 declare var WebGLTransformFeedback: {
-    readonly prototype: WebGLTransformFeedback;
+    prototype: WebGLTransformFeedback;
     new(): WebGLTransformFeedback;
 };
 
@@ -5116,7 +5116,7 @@ interface WebGLUniformLocation {
 }
 
 declare var WebGLUniformLocation: {
-    readonly prototype: WebGLUniformLocation;
+    prototype: WebGLUniformLocation;
     new(): WebGLUniformLocation;
 };
 
@@ -5124,7 +5124,7 @@ interface WebGLVertexArrayObject {
 }
 
 declare var WebGLVertexArrayObject: {
-    readonly prototype: WebGLVertexArrayObject;
+    prototype: WebGLVertexArrayObject;
     new(): WebGLVertexArrayObject;
 };
 
@@ -5191,7 +5191,7 @@ interface WebSocket extends EventTarget {
 }
 
 declare var WebSocket: {
-    readonly prototype: WebSocket;
+    prototype: WebSocket;
     new(url: string | URL, protocols?: string | string[]): WebSocket;
     readonly CLOSED: number;
     readonly CLOSING: number;
@@ -5208,7 +5208,7 @@ interface WindowClient extends Client {
 }
 
 declare var WindowClient: {
-    readonly prototype: WindowClient;
+    prototype: WindowClient;
     new(): WindowClient;
 };
 
@@ -5272,7 +5272,7 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
 }
 
 declare var WorkerGlobalScope: {
-    readonly prototype: WorkerGlobalScope;
+    prototype: WorkerGlobalScope;
     new(): WorkerGlobalScope;
 };
 
@@ -5291,7 +5291,7 @@ interface WorkerLocation {
 }
 
 declare var WorkerLocation: {
-    readonly prototype: WorkerLocation;
+    prototype: WorkerLocation;
     new(): WorkerLocation;
 };
 
@@ -5300,7 +5300,7 @@ interface WorkerNavigator extends NavigatorConcurrentHardware, NavigatorID, Navi
 }
 
 declare var WorkerNavigator: {
-    readonly prototype: WorkerNavigator;
+    prototype: WorkerNavigator;
     new(): WorkerNavigator;
 };
 
@@ -5313,7 +5313,7 @@ interface WritableStream<W = any> {
 }
 
 declare var WritableStream: {
-    readonly prototype: WritableStream;
+    prototype: WritableStream;
     new<W = any>(underlyingSink?: UnderlyingSink<W>, strategy?: QueuingStrategy<W>): WritableStream<W>;
 };
 
@@ -5323,7 +5323,7 @@ interface WritableStreamDefaultController {
 }
 
 declare var WritableStreamDefaultController: {
-    readonly prototype: WritableStreamDefaultController;
+    prototype: WritableStreamDefaultController;
     new(): WritableStreamDefaultController;
 };
 
@@ -5339,7 +5339,7 @@ interface WritableStreamDefaultWriter<W = any> {
 }
 
 declare var WritableStreamDefaultWriter: {
-    readonly prototype: WritableStreamDefaultWriter;
+    prototype: WritableStreamDefaultWriter;
     new<W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>;
 };
 
@@ -5373,7 +5373,7 @@ declare namespace WebAssembly {
     }
 
     var CompileError: {
-        readonly prototype: CompileError;
+        prototype: CompileError;
         new(): CompileError;
     };
 
@@ -5383,7 +5383,7 @@ declare namespace WebAssembly {
     }
 
     var Global: {
-        readonly prototype: Global;
+        prototype: Global;
         new(descriptor: GlobalDescriptor, v?: any): Global;
     };
 
@@ -5392,7 +5392,7 @@ declare namespace WebAssembly {
     }
 
     var Instance: {
-        readonly prototype: Instance;
+        prototype: Instance;
         new(module: Module, importObject?: Imports): Instance;
     };
 
@@ -5400,7 +5400,7 @@ declare namespace WebAssembly {
     }
 
     var LinkError: {
-        readonly prototype: LinkError;
+        prototype: LinkError;
         new(): LinkError;
     };
 
@@ -5410,7 +5410,7 @@ declare namespace WebAssembly {
     }
 
     var Memory: {
-        readonly prototype: Memory;
+        prototype: Memory;
         new(descriptor: MemoryDescriptor): Memory;
     };
 
@@ -5418,7 +5418,7 @@ declare namespace WebAssembly {
     }
 
     var Module: {
-        readonly prototype: Module;
+        prototype: Module;
         new(bytes: BufferSource): Module;
         customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
         exports(moduleObject: Module): ModuleExportDescriptor[];
@@ -5429,7 +5429,7 @@ declare namespace WebAssembly {
     }
 
     var RuntimeError: {
-        readonly prototype: RuntimeError;
+        prototype: RuntimeError;
         new(): RuntimeError;
     };
 
@@ -5441,7 +5441,7 @@ declare namespace WebAssembly {
     }
 
     var Table: {
-        readonly prototype: Table;
+        prototype: Table;
         new(descriptor: TableDescriptor, value?: any): Table;
     };
 

--- a/baselines/sharedworker.generated.d.ts
+++ b/baselines/sharedworker.generated.d.ts
@@ -656,7 +656,7 @@ interface AbortController {
 }
 
 declare var AbortController: {
-    readonly prototype: AbortController;
+    prototype: AbortController;
     new(): AbortController;
 };
 
@@ -678,7 +678,7 @@ interface AbortSignal extends EventTarget {
 }
 
 declare var AbortSignal: {
-    readonly prototype: AbortSignal;
+    prototype: AbortSignal;
     new(): AbortSignal;
 };
 
@@ -705,7 +705,7 @@ interface Blob {
 }
 
 declare var Blob: {
-    readonly prototype: Blob;
+    prototype: Blob;
     new(blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
 };
 
@@ -746,7 +746,7 @@ interface BroadcastChannel extends EventTarget {
 }
 
 declare var BroadcastChannel: {
-    readonly prototype: BroadcastChannel;
+    prototype: BroadcastChannel;
     new(name: string): BroadcastChannel;
 };
 
@@ -757,7 +757,7 @@ interface ByteLengthQueuingStrategy extends QueuingStrategy<ArrayBufferView> {
 }
 
 declare var ByteLengthQueuingStrategy: {
-    readonly prototype: ByteLengthQueuingStrategy;
+    prototype: ByteLengthQueuingStrategy;
     new(init: QueuingStrategyInit): ByteLengthQueuingStrategy;
 };
 
@@ -773,7 +773,7 @@ interface Cache {
 }
 
 declare var Cache: {
-    readonly prototype: Cache;
+    prototype: Cache;
     new(): Cache;
 };
 
@@ -787,7 +787,7 @@ interface CacheStorage {
 }
 
 declare var CacheStorage: {
-    readonly prototype: CacheStorage;
+    prototype: CacheStorage;
     new(): CacheStorage;
 };
 
@@ -802,7 +802,7 @@ interface CanvasGradient {
 }
 
 declare var CanvasGradient: {
-    readonly prototype: CanvasGradient;
+    prototype: CanvasGradient;
     new(): CanvasGradient;
 };
 
@@ -827,7 +827,7 @@ interface CanvasPattern {
 }
 
 declare var CanvasPattern: {
-    readonly prototype: CanvasPattern;
+    prototype: CanvasPattern;
     new(): CanvasPattern;
 };
 
@@ -848,7 +848,7 @@ interface CloseEvent extends Event {
 }
 
 declare var CloseEvent: {
-    readonly prototype: CloseEvent;
+    prototype: CloseEvent;
     new(type: string, eventInitDict?: CloseEventInit): CloseEvent;
 };
 
@@ -859,7 +859,7 @@ interface CountQueuingStrategy extends QueuingStrategy {
 }
 
 declare var CountQueuingStrategy: {
-    readonly prototype: CountQueuingStrategy;
+    prototype: CountQueuingStrategy;
     new(init: QueuingStrategyInit): CountQueuingStrategy;
 };
 
@@ -870,7 +870,7 @@ interface Crypto {
 }
 
 declare var Crypto: {
-    readonly prototype: Crypto;
+    prototype: Crypto;
     new(): Crypto;
 };
 
@@ -883,7 +883,7 @@ interface CryptoKey {
 }
 
 declare var CryptoKey: {
-    readonly prototype: CryptoKey;
+    prototype: CryptoKey;
     new(): CryptoKey;
 };
 
@@ -897,7 +897,7 @@ interface CustomEvent<T = any> extends Event {
 }
 
 declare var CustomEvent: {
-    readonly prototype: CustomEvent;
+    prototype: CustomEvent;
     new<T>(type: string, eventInitDict?: CustomEventInit<T>): CustomEvent<T>;
 };
 
@@ -934,7 +934,7 @@ interface DOMException {
 }
 
 declare var DOMException: {
-    readonly prototype: DOMException;
+    prototype: DOMException;
     new(message?: string, name?: string): DOMException;
     readonly ABORT_ERR: number;
     readonly DATA_CLONE_ERR: number;
@@ -978,7 +978,7 @@ interface DOMMatrix extends DOMMatrixReadOnly {
 }
 
 declare var DOMMatrix: {
-    readonly prototype: DOMMatrix;
+    prototype: DOMMatrix;
     new(init?: string | number[]): DOMMatrix;
     fromFloat32Array(array32: Float32Array): DOMMatrix;
     fromFloat64Array(array64: Float64Array): DOMMatrix;
@@ -1031,7 +1031,7 @@ interface DOMMatrixReadOnly {
 }
 
 declare var DOMMatrixReadOnly: {
-    readonly prototype: DOMMatrixReadOnly;
+    prototype: DOMMatrixReadOnly;
     new(init?: string | number[]): DOMMatrixReadOnly;
     fromFloat32Array(array32: Float32Array): DOMMatrixReadOnly;
     fromFloat64Array(array64: Float64Array): DOMMatrixReadOnly;
@@ -1042,7 +1042,7 @@ interface DOMPoint extends DOMPointReadOnly {
 }
 
 declare var DOMPoint: {
-    readonly prototype: DOMPoint;
+    prototype: DOMPoint;
     new(x?: number, y?: number, z?: number, w?: number): DOMPoint;
     fromPoint(other?: DOMPointInit): DOMPoint;
 };
@@ -1057,7 +1057,7 @@ interface DOMPointReadOnly {
 }
 
 declare var DOMPointReadOnly: {
-    readonly prototype: DOMPointReadOnly;
+    prototype: DOMPointReadOnly;
     new(x?: number, y?: number, z?: number, w?: number): DOMPointReadOnly;
     fromPoint(other?: DOMPointInit): DOMPointReadOnly;
 };
@@ -1072,7 +1072,7 @@ interface DOMQuad {
 }
 
 declare var DOMQuad: {
-    readonly prototype: DOMQuad;
+    prototype: DOMQuad;
     new(p1?: DOMPointInit, p2?: DOMPointInit, p3?: DOMPointInit, p4?: DOMPointInit): DOMQuad;
     fromQuad(other?: DOMQuadInit): DOMQuad;
     fromRect(other?: DOMRectInit): DOMQuad;
@@ -1082,7 +1082,7 @@ interface DOMRect extends DOMRectReadOnly {
 }
 
 declare var DOMRect: {
-    readonly prototype: DOMRect;
+    prototype: DOMRect;
     new(x?: number, y?: number, width?: number, height?: number): DOMRect;
     fromRect(other?: DOMRectInit): DOMRect;
 };
@@ -1100,7 +1100,7 @@ interface DOMRectReadOnly {
 }
 
 declare var DOMRectReadOnly: {
-    readonly prototype: DOMRectReadOnly;
+    prototype: DOMRectReadOnly;
     new(x?: number, y?: number, width?: number, height?: number): DOMRectReadOnly;
     fromRect(other?: DOMRectInit): DOMRectReadOnly;
 };
@@ -1123,7 +1123,7 @@ interface DOMStringList {
 }
 
 declare var DOMStringList: {
-    readonly prototype: DOMStringList;
+    prototype: DOMStringList;
     new(): DOMStringList;
 };
 
@@ -1182,7 +1182,7 @@ interface ErrorEvent extends Event {
 }
 
 declare var ErrorEvent: {
-    readonly prototype: ErrorEvent;
+    prototype: ErrorEvent;
     new(type: string, eventInitDict?: ErrorEventInit): ErrorEvent;
 };
 
@@ -1258,7 +1258,7 @@ interface Event {
 }
 
 declare var Event: {
-    readonly prototype: Event;
+    prototype: Event;
     new(type: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
@@ -1302,7 +1302,7 @@ interface EventSource extends EventTarget {
 }
 
 declare var EventSource: {
-    readonly prototype: EventSource;
+    prototype: EventSource;
     new(url: string | URL, eventSourceInitDict?: EventSourceInit): EventSource;
     readonly CLOSED: number;
     readonly CONNECTING: number;
@@ -1338,7 +1338,7 @@ interface EventTarget {
 }
 
 declare var EventTarget: {
-    readonly prototype: EventTarget;
+    prototype: EventTarget;
     new(): EventTarget;
 };
 
@@ -1350,7 +1350,7 @@ interface File extends Blob {
 }
 
 declare var File: {
-    readonly prototype: File;
+    prototype: File;
     new(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File;
 };
 
@@ -1362,7 +1362,7 @@ interface FileList {
 }
 
 declare var FileList: {
-    readonly prototype: FileList;
+    prototype: FileList;
     new(): FileList;
 };
 
@@ -1401,7 +1401,7 @@ interface FileReader extends EventTarget {
 }
 
 declare var FileReader: {
-    readonly prototype: FileReader;
+    prototype: FileReader;
     new(): FileReader;
     readonly DONE: number;
     readonly EMPTY: number;
@@ -1418,7 +1418,7 @@ interface FileReaderSync {
 }
 
 declare var FileReaderSync: {
-    readonly prototype: FileReaderSync;
+    prototype: FileReaderSync;
     new(): FileReaderSync;
 };
 
@@ -1441,7 +1441,7 @@ interface FontFace {
 }
 
 declare var FontFace: {
-    readonly prototype: FontFace;
+    prototype: FontFace;
     new(family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors): FontFace;
 };
 
@@ -1467,7 +1467,7 @@ interface FontFaceSet extends EventTarget {
 }
 
 declare var FontFaceSet: {
-    readonly prototype: FontFaceSet;
+    prototype: FontFaceSet;
     new(initialFaces: FontFace[]): FontFaceSet;
 };
 
@@ -1476,7 +1476,7 @@ interface FontFaceSetLoadEvent extends Event {
 }
 
 declare var FontFaceSetLoadEvent: {
-    readonly prototype: FontFaceSetLoadEvent;
+    prototype: FontFaceSetLoadEvent;
     new(type: string, eventInitDict?: FontFaceSetLoadEventInit): FontFaceSetLoadEvent;
 };
 
@@ -1496,7 +1496,7 @@ interface FormData {
 }
 
 declare var FormData: {
-    readonly prototype: FormData;
+    prototype: FormData;
     new(): FormData;
 };
 
@@ -1516,7 +1516,7 @@ interface Headers {
 }
 
 declare var Headers: {
-    readonly prototype: Headers;
+    prototype: Headers;
     new(init?: HeadersInit): Headers;
 };
 
@@ -1568,7 +1568,7 @@ interface IDBCursor {
 }
 
 declare var IDBCursor: {
-    readonly prototype: IDBCursor;
+    prototype: IDBCursor;
     new(): IDBCursor;
 };
 
@@ -1581,7 +1581,7 @@ interface IDBCursorWithValue extends IDBCursor {
 }
 
 declare var IDBCursorWithValue: {
-    readonly prototype: IDBCursorWithValue;
+    prototype: IDBCursorWithValue;
     new(): IDBCursorWithValue;
 };
 
@@ -1637,7 +1637,7 @@ interface IDBDatabase extends EventTarget {
 }
 
 declare var IDBDatabase: {
-    readonly prototype: IDBDatabase;
+    prototype: IDBDatabase;
     new(): IDBDatabase;
 };
 
@@ -1661,7 +1661,7 @@ interface IDBFactory {
 }
 
 declare var IDBFactory: {
-    readonly prototype: IDBFactory;
+    prototype: IDBFactory;
     new(): IDBFactory;
 };
 
@@ -1723,7 +1723,7 @@ interface IDBIndex {
 }
 
 declare var IDBIndex: {
-    readonly prototype: IDBIndex;
+    prototype: IDBIndex;
     new(): IDBIndex;
 };
 
@@ -1752,7 +1752,7 @@ interface IDBKeyRange {
 }
 
 declare var IDBKeyRange: {
-    readonly prototype: IDBKeyRange;
+    prototype: IDBKeyRange;
     new(): IDBKeyRange;
     /**
      * Returns a new IDBKeyRange spanning from lower to upper. If lowerOpen is true, lower is not included in the range. If upperOpen is true, upper is not included in the range.
@@ -1884,7 +1884,7 @@ interface IDBObjectStore {
 }
 
 declare var IDBObjectStore: {
-    readonly prototype: IDBObjectStore;
+    prototype: IDBObjectStore;
     new(): IDBObjectStore;
 };
 
@@ -1904,7 +1904,7 @@ interface IDBOpenDBRequest extends IDBRequest<IDBDatabase> {
 }
 
 declare var IDBOpenDBRequest: {
-    readonly prototype: IDBOpenDBRequest;
+    prototype: IDBOpenDBRequest;
     new(): IDBOpenDBRequest;
 };
 
@@ -1944,7 +1944,7 @@ interface IDBRequest<T = any> extends EventTarget {
 }
 
 declare var IDBRequest: {
-    readonly prototype: IDBRequest;
+    prototype: IDBRequest;
     new(): IDBRequest;
 };
 
@@ -1990,7 +1990,7 @@ interface IDBTransaction extends EventTarget {
 }
 
 declare var IDBTransaction: {
-    readonly prototype: IDBTransaction;
+    prototype: IDBTransaction;
     new(): IDBTransaction;
 };
 
@@ -2001,7 +2001,7 @@ interface IDBVersionChangeEvent extends Event {
 }
 
 declare var IDBVersionChangeEvent: {
-    readonly prototype: IDBVersionChangeEvent;
+    prototype: IDBVersionChangeEvent;
     new(type: string, eventInitDict?: IDBVersionChangeEventInit): IDBVersionChangeEvent;
 };
 
@@ -2021,7 +2021,7 @@ interface ImageBitmap {
 }
 
 declare var ImageBitmap: {
-    readonly prototype: ImageBitmap;
+    prototype: ImageBitmap;
     new(): ImageBitmap;
 };
 
@@ -2033,7 +2033,7 @@ interface ImageBitmapRenderingContext {
 }
 
 declare var ImageBitmapRenderingContext: {
-    readonly prototype: ImageBitmapRenderingContext;
+    prototype: ImageBitmapRenderingContext;
     new(): ImageBitmapRenderingContext;
 };
 
@@ -2054,7 +2054,7 @@ interface ImageData {
 }
 
 declare var ImageData: {
-    readonly prototype: ImageData;
+    prototype: ImageData;
     new(sw: number, sh: number, settings?: ImageDataSettings): ImageData;
     new(data: Uint8ClampedArray, sw: number, sh?: number, settings?: ImageDataSettings): ImageData;
 };
@@ -2069,7 +2069,7 @@ interface MediaCapabilities {
 }
 
 declare var MediaCapabilities: {
-    readonly prototype: MediaCapabilities;
+    prototype: MediaCapabilities;
     new(): MediaCapabilities;
 };
 
@@ -2086,7 +2086,7 @@ interface MessageChannel {
 }
 
 declare var MessageChannel: {
-    readonly prototype: MessageChannel;
+    prototype: MessageChannel;
     new(): MessageChannel;
 };
 
@@ -2117,7 +2117,7 @@ interface MessageEvent<T = any> extends Event {
 }
 
 declare var MessageEvent: {
-    readonly prototype: MessageEvent;
+    prototype: MessageEvent;
     new<T>(type: string, eventInitDict?: MessageEventInit<T>): MessageEvent<T>;
 };
 
@@ -2152,7 +2152,7 @@ interface MessagePort extends EventTarget {
 }
 
 declare var MessagePort: {
-    readonly prototype: MessagePort;
+    prototype: MessagePort;
     new(): MessagePort;
 };
 
@@ -2196,7 +2196,7 @@ interface NetworkInformation extends EventTarget {
 }
 
 declare var NetworkInformation: {
-    readonly prototype: NetworkInformation;
+    prototype: NetworkInformation;
     new(): NetworkInformation;
 };
 
@@ -2228,7 +2228,7 @@ interface Notification extends EventTarget {
 }
 
 declare var Notification: {
-    readonly prototype: Notification;
+    prototype: Notification;
     new(title: string, options?: NotificationOptions): Notification;
     readonly permission: NotificationPermission;
 };
@@ -2287,7 +2287,7 @@ interface Path2D extends CanvasPath {
 }
 
 declare var Path2D: {
-    readonly prototype: Path2D;
+    prototype: Path2D;
     new(path?: Path2D | string): Path2D;
 };
 
@@ -2317,7 +2317,7 @@ interface Performance extends EventTarget {
 }
 
 declare var Performance: {
-    readonly prototype: Performance;
+    prototype: Performance;
     new(): Performance;
 };
 
@@ -2331,7 +2331,7 @@ interface PerformanceEntry {
 }
 
 declare var PerformanceEntry: {
-    readonly prototype: PerformanceEntry;
+    prototype: PerformanceEntry;
     new(): PerformanceEntry;
 };
 
@@ -2341,7 +2341,7 @@ interface PerformanceMark extends PerformanceEntry {
 }
 
 declare var PerformanceMark: {
-    readonly prototype: PerformanceMark;
+    prototype: PerformanceMark;
     new(markName: string, markOptions?: PerformanceMarkOptions): PerformanceMark;
 };
 
@@ -2351,7 +2351,7 @@ interface PerformanceMeasure extends PerformanceEntry {
 }
 
 declare var PerformanceMeasure: {
-    readonly prototype: PerformanceMeasure;
+    prototype: PerformanceMeasure;
     new(): PerformanceMeasure;
 };
 
@@ -2362,7 +2362,7 @@ interface PerformanceObserver {
 }
 
 declare var PerformanceObserver: {
-    readonly prototype: PerformanceObserver;
+    prototype: PerformanceObserver;
     new(callback: PerformanceObserverCallback): PerformanceObserver;
     readonly supportedEntryTypes: ReadonlyArray<string>;
 };
@@ -2374,7 +2374,7 @@ interface PerformanceObserverEntryList {
 }
 
 declare var PerformanceObserverEntryList: {
-    readonly prototype: PerformanceObserverEntryList;
+    prototype: PerformanceObserverEntryList;
     new(): PerformanceObserverEntryList;
 };
 
@@ -2402,7 +2402,7 @@ interface PerformanceResourceTiming extends PerformanceEntry {
 }
 
 declare var PerformanceResourceTiming: {
-    readonly prototype: PerformanceResourceTiming;
+    prototype: PerformanceResourceTiming;
     new(): PerformanceResourceTiming;
 };
 
@@ -2414,7 +2414,7 @@ interface PerformanceServerTiming {
 }
 
 declare var PerformanceServerTiming: {
-    readonly prototype: PerformanceServerTiming;
+    prototype: PerformanceServerTiming;
     new(): PerformanceServerTiming;
 };
 
@@ -2432,7 +2432,7 @@ interface PermissionStatus extends EventTarget {
 }
 
 declare var PermissionStatus: {
-    readonly prototype: PermissionStatus;
+    prototype: PermissionStatus;
     new(): PermissionStatus;
 };
 
@@ -2441,7 +2441,7 @@ interface Permissions {
 }
 
 declare var Permissions: {
-    readonly prototype: Permissions;
+    prototype: Permissions;
     new(): Permissions;
 };
 
@@ -2454,7 +2454,7 @@ interface ProgressEvent<T extends EventTarget = EventTarget> extends Event {
 }
 
 declare var ProgressEvent: {
-    readonly prototype: ProgressEvent;
+    prototype: ProgressEvent;
     new(type: string, eventInitDict?: ProgressEventInit): ProgressEvent;
 };
 
@@ -2464,7 +2464,7 @@ interface PromiseRejectionEvent extends Event {
 }
 
 declare var PromiseRejectionEvent: {
-    readonly prototype: PromiseRejectionEvent;
+    prototype: PromiseRejectionEvent;
     new(type: string, eventInitDict: PromiseRejectionEventInit): PromiseRejectionEvent;
 };
 
@@ -2476,7 +2476,7 @@ interface PushManager {
 }
 
 declare var PushManager: {
-    readonly prototype: PushManager;
+    prototype: PushManager;
     new(): PushManager;
     readonly supportedContentEncodings: ReadonlyArray<string>;
 };
@@ -2491,7 +2491,7 @@ interface PushSubscription {
 }
 
 declare var PushSubscription: {
-    readonly prototype: PushSubscription;
+    prototype: PushSubscription;
     new(): PushSubscription;
 };
 
@@ -2500,7 +2500,7 @@ interface PushSubscriptionOptions {
 }
 
 declare var PushSubscriptionOptions: {
-    readonly prototype: PushSubscriptionOptions;
+    prototype: PushSubscriptionOptions;
     new(): PushSubscriptionOptions;
 };
 
@@ -2516,7 +2516,7 @@ interface ReadableStream<R = any> {
 }
 
 declare var ReadableStream: {
-    readonly prototype: ReadableStream;
+    prototype: ReadableStream;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 
@@ -2528,7 +2528,7 @@ interface ReadableStreamDefaultController<R = any> {
 }
 
 declare var ReadableStreamDefaultController: {
-    readonly prototype: ReadableStreamDefaultController;
+    prototype: ReadableStreamDefaultController;
     new(): ReadableStreamDefaultController;
 };
 
@@ -2538,7 +2538,7 @@ interface ReadableStreamDefaultReader<R = any> extends ReadableStreamGenericRead
 }
 
 declare var ReadableStreamDefaultReader: {
-    readonly prototype: ReadableStreamDefaultReader;
+    prototype: ReadableStreamDefaultReader;
     new<R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>;
 };
 
@@ -2605,7 +2605,7 @@ interface Request extends Body {
 }
 
 declare var Request: {
-    readonly prototype: Request;
+    prototype: Request;
     new(input: RequestInfo, init?: RequestInit): Request;
 };
 
@@ -2622,7 +2622,7 @@ interface Response extends Body {
 }
 
 declare var Response: {
-    readonly prototype: Response;
+    prototype: Response;
     new(body?: BodyInit | null, init?: ResponseInit): Response;
     error(): Response;
     redirect(url: string | URL, status?: number): Response;
@@ -2645,7 +2645,7 @@ interface SecurityPolicyViolationEvent extends Event {
 }
 
 declare var SecurityPolicyViolationEvent: {
-    readonly prototype: SecurityPolicyViolationEvent;
+    prototype: SecurityPolicyViolationEvent;
     new(type: string, eventInitDict?: SecurityPolicyViolationEventInit): SecurityPolicyViolationEvent;
 };
 
@@ -2667,7 +2667,7 @@ interface ServiceWorker extends EventTarget, AbstractWorker {
 }
 
 declare var ServiceWorker: {
-    readonly prototype: ServiceWorker;
+    prototype: ServiceWorker;
     new(): ServiceWorker;
 };
 
@@ -2695,7 +2695,7 @@ interface ServiceWorkerContainer extends EventTarget {
 }
 
 declare var ServiceWorkerContainer: {
-    readonly prototype: ServiceWorkerContainer;
+    prototype: ServiceWorkerContainer;
     new(): ServiceWorkerContainer;
 };
 
@@ -2723,7 +2723,7 @@ interface ServiceWorkerRegistration extends EventTarget {
 }
 
 declare var ServiceWorkerRegistration: {
-    readonly prototype: ServiceWorkerRegistration;
+    prototype: ServiceWorkerRegistration;
     new(): ServiceWorkerRegistration;
 };
 
@@ -2748,7 +2748,7 @@ interface SharedWorkerGlobalScope extends WorkerGlobalScope {
 }
 
 declare var SharedWorkerGlobalScope: {
-    readonly prototype: SharedWorkerGlobalScope;
+    prototype: SharedWorkerGlobalScope;
     new(): SharedWorkerGlobalScope;
 };
 
@@ -2758,7 +2758,7 @@ interface StorageManager {
 }
 
 declare var StorageManager: {
-    readonly prototype: StorageManager;
+    prototype: StorageManager;
     new(): StorageManager;
 };
 
@@ -2783,7 +2783,7 @@ interface SubtleCrypto {
 }
 
 declare var SubtleCrypto: {
-    readonly prototype: SubtleCrypto;
+    prototype: SubtleCrypto;
     new(): SubtleCrypto;
 };
 
@@ -2806,7 +2806,7 @@ interface TextDecoder extends TextDecoderCommon {
 }
 
 declare var TextDecoder: {
-    readonly prototype: TextDecoder;
+    prototype: TextDecoder;
     new(label?: string, options?: TextDecoderOptions): TextDecoder;
 };
 
@@ -2831,7 +2831,7 @@ interface TextDecoderStream extends GenericTransformStream, TextDecoderCommon {
 }
 
 declare var TextDecoderStream: {
-    readonly prototype: TextDecoderStream;
+    prototype: TextDecoderStream;
     new(label?: string, options?: TextDecoderOptions): TextDecoderStream;
 };
 
@@ -2848,7 +2848,7 @@ interface TextEncoder extends TextEncoderCommon {
 }
 
 declare var TextEncoder: {
-    readonly prototype: TextEncoder;
+    prototype: TextEncoder;
     new(): TextEncoder;
 };
 
@@ -2865,7 +2865,7 @@ interface TextEncoderStream extends GenericTransformStream, TextEncoderCommon {
 }
 
 declare var TextEncoderStream: {
-    readonly prototype: TextEncoderStream;
+    prototype: TextEncoderStream;
     new(): TextEncoderStream;
 };
 
@@ -2902,7 +2902,7 @@ interface TextMetrics {
 }
 
 declare var TextMetrics: {
-    readonly prototype: TextMetrics;
+    prototype: TextMetrics;
     new(): TextMetrics;
 };
 
@@ -2912,7 +2912,7 @@ interface TransformStream<I = any, O = any> {
 }
 
 declare var TransformStream: {
-    readonly prototype: TransformStream;
+    prototype: TransformStream;
     new<I = any, O = any>(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>): TransformStream<I, O>;
 };
 
@@ -2924,7 +2924,7 @@ interface TransformStreamDefaultController<O = any> {
 }
 
 declare var TransformStreamDefaultController: {
-    readonly prototype: TransformStreamDefaultController;
+    prototype: TransformStreamDefaultController;
     new(): TransformStreamDefaultController;
 };
 
@@ -2947,7 +2947,7 @@ interface URL {
 }
 
 declare var URL: {
-    readonly prototype: URL;
+    prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
     createObjectURL(object: any): string;
     revokeObjectURL(url: string): void;
@@ -2987,7 +2987,7 @@ interface URLSearchParams {
 }
 
 declare var URLSearchParams: {
-    readonly prototype: URLSearchParams;
+    prototype: URLSearchParams;
     new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
     toString(): string;
 };
@@ -3131,7 +3131,7 @@ interface WebGL2RenderingContext extends WebGL2RenderingContextBase, WebGL2Rende
 }
 
 declare var WebGL2RenderingContext: {
-    readonly prototype: WebGL2RenderingContext;
+    prototype: WebGL2RenderingContext;
     new(): WebGL2RenderingContext;
     readonly ACTIVE_UNIFORM_BLOCKS: GLenum;
     readonly ALREADY_SIGNALED: GLenum;
@@ -4099,7 +4099,7 @@ interface WebGLActiveInfo {
 }
 
 declare var WebGLActiveInfo: {
-    readonly prototype: WebGLActiveInfo;
+    prototype: WebGLActiveInfo;
     new(): WebGLActiveInfo;
 };
 
@@ -4108,7 +4108,7 @@ interface WebGLBuffer {
 }
 
 declare var WebGLBuffer: {
-    readonly prototype: WebGLBuffer;
+    prototype: WebGLBuffer;
     new(): WebGLBuffer;
 };
 
@@ -4118,7 +4118,7 @@ interface WebGLContextEvent extends Event {
 }
 
 declare var WebGLContextEvent: {
-    readonly prototype: WebGLContextEvent;
+    prototype: WebGLContextEvent;
     new(type: string, eventInit?: WebGLContextEventInit): WebGLContextEvent;
 };
 
@@ -4127,7 +4127,7 @@ interface WebGLFramebuffer {
 }
 
 declare var WebGLFramebuffer: {
-    readonly prototype: WebGLFramebuffer;
+    prototype: WebGLFramebuffer;
     new(): WebGLFramebuffer;
 };
 
@@ -4136,7 +4136,7 @@ interface WebGLProgram {
 }
 
 declare var WebGLProgram: {
-    readonly prototype: WebGLProgram;
+    prototype: WebGLProgram;
     new(): WebGLProgram;
 };
 
@@ -4144,7 +4144,7 @@ interface WebGLQuery {
 }
 
 declare var WebGLQuery: {
-    readonly prototype: WebGLQuery;
+    prototype: WebGLQuery;
     new(): WebGLQuery;
 };
 
@@ -4153,7 +4153,7 @@ interface WebGLRenderbuffer {
 }
 
 declare var WebGLRenderbuffer: {
-    readonly prototype: WebGLRenderbuffer;
+    prototype: WebGLRenderbuffer;
     new(): WebGLRenderbuffer;
 };
 
@@ -4162,7 +4162,7 @@ interface WebGLRenderingContext extends WebGLRenderingContextBase, WebGLRenderin
 }
 
 declare var WebGLRenderingContext: {
-    readonly prototype: WebGLRenderingContext;
+    prototype: WebGLRenderingContext;
     new(): WebGLRenderingContext;
     readonly ACTIVE_ATTRIBUTES: GLenum;
     readonly ACTIVE_TEXTURE: GLenum;
@@ -4939,7 +4939,7 @@ interface WebGLSampler {
 }
 
 declare var WebGLSampler: {
-    readonly prototype: WebGLSampler;
+    prototype: WebGLSampler;
     new(): WebGLSampler;
 };
 
@@ -4948,7 +4948,7 @@ interface WebGLShader {
 }
 
 declare var WebGLShader: {
-    readonly prototype: WebGLShader;
+    prototype: WebGLShader;
     new(): WebGLShader;
 };
 
@@ -4960,7 +4960,7 @@ interface WebGLShaderPrecisionFormat {
 }
 
 declare var WebGLShaderPrecisionFormat: {
-    readonly prototype: WebGLShaderPrecisionFormat;
+    prototype: WebGLShaderPrecisionFormat;
     new(): WebGLShaderPrecisionFormat;
 };
 
@@ -4968,7 +4968,7 @@ interface WebGLSync {
 }
 
 declare var WebGLSync: {
-    readonly prototype: WebGLSync;
+    prototype: WebGLSync;
     new(): WebGLSync;
 };
 
@@ -4977,7 +4977,7 @@ interface WebGLTexture {
 }
 
 declare var WebGLTexture: {
-    readonly prototype: WebGLTexture;
+    prototype: WebGLTexture;
     new(): WebGLTexture;
 };
 
@@ -4985,7 +4985,7 @@ interface WebGLTransformFeedback {
 }
 
 declare var WebGLTransformFeedback: {
-    readonly prototype: WebGLTransformFeedback;
+    prototype: WebGLTransformFeedback;
     new(): WebGLTransformFeedback;
 };
 
@@ -4994,7 +4994,7 @@ interface WebGLUniformLocation {
 }
 
 declare var WebGLUniformLocation: {
-    readonly prototype: WebGLUniformLocation;
+    prototype: WebGLUniformLocation;
     new(): WebGLUniformLocation;
 };
 
@@ -5002,7 +5002,7 @@ interface WebGLVertexArrayObject {
 }
 
 declare var WebGLVertexArrayObject: {
-    readonly prototype: WebGLVertexArrayObject;
+    prototype: WebGLVertexArrayObject;
     new(): WebGLVertexArrayObject;
 };
 
@@ -5069,7 +5069,7 @@ interface WebSocket extends EventTarget {
 }
 
 declare var WebSocket: {
-    readonly prototype: WebSocket;
+    prototype: WebSocket;
     new(url: string | URL, protocols?: string | string[]): WebSocket;
     readonly CLOSED: number;
     readonly CLOSING: number;
@@ -5122,7 +5122,7 @@ interface Worker extends EventTarget, AbstractWorker {
 }
 
 declare var Worker: {
-    readonly prototype: Worker;
+    prototype: Worker;
     new(scriptURL: string | URL, options?: WorkerOptions): Worker;
 };
 
@@ -5166,7 +5166,7 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
 }
 
 declare var WorkerGlobalScope: {
-    readonly prototype: WorkerGlobalScope;
+    prototype: WorkerGlobalScope;
     new(): WorkerGlobalScope;
 };
 
@@ -5185,7 +5185,7 @@ interface WorkerLocation {
 }
 
 declare var WorkerLocation: {
-    readonly prototype: WorkerLocation;
+    prototype: WorkerLocation;
     new(): WorkerLocation;
 };
 
@@ -5194,7 +5194,7 @@ interface WorkerNavigator extends NavigatorConcurrentHardware, NavigatorID, Navi
 }
 
 declare var WorkerNavigator: {
-    readonly prototype: WorkerNavigator;
+    prototype: WorkerNavigator;
     new(): WorkerNavigator;
 };
 
@@ -5207,7 +5207,7 @@ interface WritableStream<W = any> {
 }
 
 declare var WritableStream: {
-    readonly prototype: WritableStream;
+    prototype: WritableStream;
     new<W = any>(underlyingSink?: UnderlyingSink<W>, strategy?: QueuingStrategy<W>): WritableStream<W>;
 };
 
@@ -5217,7 +5217,7 @@ interface WritableStreamDefaultController {
 }
 
 declare var WritableStreamDefaultController: {
-    readonly prototype: WritableStreamDefaultController;
+    prototype: WritableStreamDefaultController;
     new(): WritableStreamDefaultController;
 };
 
@@ -5233,7 +5233,7 @@ interface WritableStreamDefaultWriter<W = any> {
 }
 
 declare var WritableStreamDefaultWriter: {
-    readonly prototype: WritableStreamDefaultWriter;
+    prototype: WritableStreamDefaultWriter;
     new<W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>;
 };
 
@@ -5338,7 +5338,7 @@ interface XMLHttpRequest extends XMLHttpRequestEventTarget {
 }
 
 declare var XMLHttpRequest: {
-    readonly prototype: XMLHttpRequest;
+    prototype: XMLHttpRequest;
     new(): XMLHttpRequest;
     readonly DONE: number;
     readonly HEADERS_RECEIVED: number;
@@ -5372,7 +5372,7 @@ interface XMLHttpRequestEventTarget extends EventTarget {
 }
 
 declare var XMLHttpRequestEventTarget: {
-    readonly prototype: XMLHttpRequestEventTarget;
+    prototype: XMLHttpRequestEventTarget;
     new(): XMLHttpRequestEventTarget;
 };
 
@@ -5384,7 +5384,7 @@ interface XMLHttpRequestUpload extends XMLHttpRequestEventTarget {
 }
 
 declare var XMLHttpRequestUpload: {
-    readonly prototype: XMLHttpRequestUpload;
+    prototype: XMLHttpRequestUpload;
     new(): XMLHttpRequestUpload;
 };
 
@@ -5418,7 +5418,7 @@ declare namespace WebAssembly {
     }
 
     var CompileError: {
-        readonly prototype: CompileError;
+        prototype: CompileError;
         new(): CompileError;
     };
 
@@ -5428,7 +5428,7 @@ declare namespace WebAssembly {
     }
 
     var Global: {
-        readonly prototype: Global;
+        prototype: Global;
         new(descriptor: GlobalDescriptor, v?: any): Global;
     };
 
@@ -5437,7 +5437,7 @@ declare namespace WebAssembly {
     }
 
     var Instance: {
-        readonly prototype: Instance;
+        prototype: Instance;
         new(module: Module, importObject?: Imports): Instance;
     };
 
@@ -5445,7 +5445,7 @@ declare namespace WebAssembly {
     }
 
     var LinkError: {
-        readonly prototype: LinkError;
+        prototype: LinkError;
         new(): LinkError;
     };
 
@@ -5455,7 +5455,7 @@ declare namespace WebAssembly {
     }
 
     var Memory: {
-        readonly prototype: Memory;
+        prototype: Memory;
         new(descriptor: MemoryDescriptor): Memory;
     };
 
@@ -5463,7 +5463,7 @@ declare namespace WebAssembly {
     }
 
     var Module: {
-        readonly prototype: Module;
+        prototype: Module;
         new(bytes: BufferSource): Module;
         customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
         exports(moduleObject: Module): ModuleExportDescriptor[];
@@ -5474,7 +5474,7 @@ declare namespace WebAssembly {
     }
 
     var RuntimeError: {
-        readonly prototype: RuntimeError;
+        prototype: RuntimeError;
         new(): RuntimeError;
     };
 
@@ -5486,7 +5486,7 @@ declare namespace WebAssembly {
     }
 
     var Table: {
-        readonly prototype: Table;
+        prototype: Table;
         new(descriptor: TableDescriptor, value?: any): Table;
     };
 

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -690,7 +690,7 @@ interface AbortController {
 }
 
 declare var AbortController: {
-    readonly prototype: AbortController;
+    prototype: AbortController;
     new(): AbortController;
 };
 
@@ -712,7 +712,7 @@ interface AbortSignal extends EventTarget {
 }
 
 declare var AbortSignal: {
-    readonly prototype: AbortSignal;
+    prototype: AbortSignal;
     new(): AbortSignal;
 };
 
@@ -744,7 +744,7 @@ interface Blob {
 }
 
 declare var Blob: {
-    readonly prototype: Blob;
+    prototype: Blob;
     new(blobParts?: BlobPart[], options?: BlobPropertyBag): Blob;
 };
 
@@ -785,7 +785,7 @@ interface BroadcastChannel extends EventTarget {
 }
 
 declare var BroadcastChannel: {
-    readonly prototype: BroadcastChannel;
+    prototype: BroadcastChannel;
     new(name: string): BroadcastChannel;
 };
 
@@ -796,7 +796,7 @@ interface ByteLengthQueuingStrategy extends QueuingStrategy<ArrayBufferView> {
 }
 
 declare var ByteLengthQueuingStrategy: {
-    readonly prototype: ByteLengthQueuingStrategy;
+    prototype: ByteLengthQueuingStrategy;
     new(init: QueuingStrategyInit): ByteLengthQueuingStrategy;
 };
 
@@ -812,7 +812,7 @@ interface Cache {
 }
 
 declare var Cache: {
-    readonly prototype: Cache;
+    prototype: Cache;
     new(): Cache;
 };
 
@@ -826,7 +826,7 @@ interface CacheStorage {
 }
 
 declare var CacheStorage: {
-    readonly prototype: CacheStorage;
+    prototype: CacheStorage;
     new(): CacheStorage;
 };
 
@@ -841,7 +841,7 @@ interface CanvasGradient {
 }
 
 declare var CanvasGradient: {
-    readonly prototype: CanvasGradient;
+    prototype: CanvasGradient;
     new(): CanvasGradient;
 };
 
@@ -866,7 +866,7 @@ interface CanvasPattern {
 }
 
 declare var CanvasPattern: {
-    readonly prototype: CanvasPattern;
+    prototype: CanvasPattern;
     new(): CanvasPattern;
 };
 
@@ -881,7 +881,7 @@ interface Client {
 }
 
 declare var Client: {
-    readonly prototype: Client;
+    prototype: Client;
     new(): Client;
 };
 
@@ -894,7 +894,7 @@ interface Clients {
 }
 
 declare var Clients: {
-    readonly prototype: Clients;
+    prototype: Clients;
     new(): Clients;
 };
 
@@ -915,7 +915,7 @@ interface CloseEvent extends Event {
 }
 
 declare var CloseEvent: {
-    readonly prototype: CloseEvent;
+    prototype: CloseEvent;
     new(type: string, eventInitDict?: CloseEventInit): CloseEvent;
 };
 
@@ -926,7 +926,7 @@ interface CountQueuingStrategy extends QueuingStrategy {
 }
 
 declare var CountQueuingStrategy: {
-    readonly prototype: CountQueuingStrategy;
+    prototype: CountQueuingStrategy;
     new(init: QueuingStrategyInit): CountQueuingStrategy;
 };
 
@@ -937,7 +937,7 @@ interface Crypto {
 }
 
 declare var Crypto: {
-    readonly prototype: Crypto;
+    prototype: Crypto;
     new(): Crypto;
 };
 
@@ -950,7 +950,7 @@ interface CryptoKey {
 }
 
 declare var CryptoKey: {
-    readonly prototype: CryptoKey;
+    prototype: CryptoKey;
     new(): CryptoKey;
 };
 
@@ -964,7 +964,7 @@ interface CustomEvent<T = any> extends Event {
 }
 
 declare var CustomEvent: {
-    readonly prototype: CustomEvent;
+    prototype: CustomEvent;
     new<T>(type: string, eventInitDict?: CustomEventInit<T>): CustomEvent<T>;
 };
 
@@ -1001,7 +1001,7 @@ interface DOMException {
 }
 
 declare var DOMException: {
-    readonly prototype: DOMException;
+    prototype: DOMException;
     new(message?: string, name?: string): DOMException;
     readonly ABORT_ERR: number;
     readonly DATA_CLONE_ERR: number;
@@ -1045,7 +1045,7 @@ interface DOMMatrix extends DOMMatrixReadOnly {
 }
 
 declare var DOMMatrix: {
-    readonly prototype: DOMMatrix;
+    prototype: DOMMatrix;
     new(init?: string | number[]): DOMMatrix;
     fromFloat32Array(array32: Float32Array): DOMMatrix;
     fromFloat64Array(array64: Float64Array): DOMMatrix;
@@ -1098,7 +1098,7 @@ interface DOMMatrixReadOnly {
 }
 
 declare var DOMMatrixReadOnly: {
-    readonly prototype: DOMMatrixReadOnly;
+    prototype: DOMMatrixReadOnly;
     new(init?: string | number[]): DOMMatrixReadOnly;
     fromFloat32Array(array32: Float32Array): DOMMatrixReadOnly;
     fromFloat64Array(array64: Float64Array): DOMMatrixReadOnly;
@@ -1109,7 +1109,7 @@ interface DOMPoint extends DOMPointReadOnly {
 }
 
 declare var DOMPoint: {
-    readonly prototype: DOMPoint;
+    prototype: DOMPoint;
     new(x?: number, y?: number, z?: number, w?: number): DOMPoint;
     fromPoint(other?: DOMPointInit): DOMPoint;
 };
@@ -1124,7 +1124,7 @@ interface DOMPointReadOnly {
 }
 
 declare var DOMPointReadOnly: {
-    readonly prototype: DOMPointReadOnly;
+    prototype: DOMPointReadOnly;
     new(x?: number, y?: number, z?: number, w?: number): DOMPointReadOnly;
     fromPoint(other?: DOMPointInit): DOMPointReadOnly;
 };
@@ -1139,7 +1139,7 @@ interface DOMQuad {
 }
 
 declare var DOMQuad: {
-    readonly prototype: DOMQuad;
+    prototype: DOMQuad;
     new(p1?: DOMPointInit, p2?: DOMPointInit, p3?: DOMPointInit, p4?: DOMPointInit): DOMQuad;
     fromQuad(other?: DOMQuadInit): DOMQuad;
     fromRect(other?: DOMRectInit): DOMQuad;
@@ -1149,7 +1149,7 @@ interface DOMRect extends DOMRectReadOnly {
 }
 
 declare var DOMRect: {
-    readonly prototype: DOMRect;
+    prototype: DOMRect;
     new(x?: number, y?: number, width?: number, height?: number): DOMRect;
     fromRect(other?: DOMRectInit): DOMRect;
 };
@@ -1167,7 +1167,7 @@ interface DOMRectReadOnly {
 }
 
 declare var DOMRectReadOnly: {
-    readonly prototype: DOMRectReadOnly;
+    prototype: DOMRectReadOnly;
     new(x?: number, y?: number, width?: number, height?: number): DOMRectReadOnly;
     fromRect(other?: DOMRectInit): DOMRectReadOnly;
 };
@@ -1190,7 +1190,7 @@ interface DOMStringList {
 }
 
 declare var DOMStringList: {
-    readonly prototype: DOMStringList;
+    prototype: DOMStringList;
     new(): DOMStringList;
 };
 
@@ -1223,7 +1223,7 @@ interface DedicatedWorkerGlobalScope extends WorkerGlobalScope, AnimationFramePr
 }
 
 declare var DedicatedWorkerGlobalScope: {
-    readonly prototype: DedicatedWorkerGlobalScope;
+    prototype: DedicatedWorkerGlobalScope;
     new(): DedicatedWorkerGlobalScope;
 };
 
@@ -1282,7 +1282,7 @@ interface ErrorEvent extends Event {
 }
 
 declare var ErrorEvent: {
-    readonly prototype: ErrorEvent;
+    prototype: ErrorEvent;
     new(type: string, eventInitDict?: ErrorEventInit): ErrorEvent;
 };
 
@@ -1358,7 +1358,7 @@ interface Event {
 }
 
 declare var Event: {
-    readonly prototype: Event;
+    prototype: Event;
     new(type: string, eventInitDict?: EventInit): Event;
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
@@ -1402,7 +1402,7 @@ interface EventSource extends EventTarget {
 }
 
 declare var EventSource: {
-    readonly prototype: EventSource;
+    prototype: EventSource;
     new(url: string | URL, eventSourceInitDict?: EventSourceInit): EventSource;
     readonly CLOSED: number;
     readonly CONNECTING: number;
@@ -1438,7 +1438,7 @@ interface EventTarget {
 }
 
 declare var EventTarget: {
-    readonly prototype: EventTarget;
+    prototype: EventTarget;
     new(): EventTarget;
 };
 
@@ -1448,7 +1448,7 @@ interface ExtendableEvent extends Event {
 }
 
 declare var ExtendableEvent: {
-    readonly prototype: ExtendableEvent;
+    prototype: ExtendableEvent;
     new(type: string, eventInitDict?: ExtendableEventInit): ExtendableEvent;
 };
 
@@ -1462,7 +1462,7 @@ interface ExtendableMessageEvent extends ExtendableEvent {
 }
 
 declare var ExtendableMessageEvent: {
-    readonly prototype: ExtendableMessageEvent;
+    prototype: ExtendableMessageEvent;
     new(type: string, eventInitDict?: ExtendableMessageEventInit): ExtendableMessageEvent;
 };
 
@@ -1475,7 +1475,7 @@ interface FetchEvent extends ExtendableEvent {
 }
 
 declare var FetchEvent: {
-    readonly prototype: FetchEvent;
+    prototype: FetchEvent;
     new(type: string, eventInitDict: FetchEventInit): FetchEvent;
 };
 
@@ -1487,7 +1487,7 @@ interface File extends Blob {
 }
 
 declare var File: {
-    readonly prototype: File;
+    prototype: File;
     new(fileBits: BlobPart[], fileName: string, options?: FilePropertyBag): File;
 };
 
@@ -1499,7 +1499,7 @@ interface FileList {
 }
 
 declare var FileList: {
-    readonly prototype: FileList;
+    prototype: FileList;
     new(): FileList;
 };
 
@@ -1538,7 +1538,7 @@ interface FileReader extends EventTarget {
 }
 
 declare var FileReader: {
-    readonly prototype: FileReader;
+    prototype: FileReader;
     new(): FileReader;
     readonly DONE: number;
     readonly EMPTY: number;
@@ -1555,7 +1555,7 @@ interface FileReaderSync {
 }
 
 declare var FileReaderSync: {
-    readonly prototype: FileReaderSync;
+    prototype: FileReaderSync;
     new(): FileReaderSync;
 };
 
@@ -1578,7 +1578,7 @@ interface FontFace {
 }
 
 declare var FontFace: {
-    readonly prototype: FontFace;
+    prototype: FontFace;
     new(family: string, source: string | BinaryData, descriptors?: FontFaceDescriptors): FontFace;
 };
 
@@ -1604,7 +1604,7 @@ interface FontFaceSet extends EventTarget {
 }
 
 declare var FontFaceSet: {
-    readonly prototype: FontFaceSet;
+    prototype: FontFaceSet;
     new(initialFaces: FontFace[]): FontFaceSet;
 };
 
@@ -1613,7 +1613,7 @@ interface FontFaceSetLoadEvent extends Event {
 }
 
 declare var FontFaceSetLoadEvent: {
-    readonly prototype: FontFaceSetLoadEvent;
+    prototype: FontFaceSetLoadEvent;
     new(type: string, eventInitDict?: FontFaceSetLoadEventInit): FontFaceSetLoadEvent;
 };
 
@@ -1633,7 +1633,7 @@ interface FormData {
 }
 
 declare var FormData: {
-    readonly prototype: FormData;
+    prototype: FormData;
     new(): FormData;
 };
 
@@ -1653,7 +1653,7 @@ interface Headers {
 }
 
 declare var Headers: {
-    readonly prototype: Headers;
+    prototype: Headers;
     new(init?: HeadersInit): Headers;
 };
 
@@ -1705,7 +1705,7 @@ interface IDBCursor {
 }
 
 declare var IDBCursor: {
-    readonly prototype: IDBCursor;
+    prototype: IDBCursor;
     new(): IDBCursor;
 };
 
@@ -1718,7 +1718,7 @@ interface IDBCursorWithValue extends IDBCursor {
 }
 
 declare var IDBCursorWithValue: {
-    readonly prototype: IDBCursorWithValue;
+    prototype: IDBCursorWithValue;
     new(): IDBCursorWithValue;
 };
 
@@ -1774,7 +1774,7 @@ interface IDBDatabase extends EventTarget {
 }
 
 declare var IDBDatabase: {
-    readonly prototype: IDBDatabase;
+    prototype: IDBDatabase;
     new(): IDBDatabase;
 };
 
@@ -1798,7 +1798,7 @@ interface IDBFactory {
 }
 
 declare var IDBFactory: {
-    readonly prototype: IDBFactory;
+    prototype: IDBFactory;
     new(): IDBFactory;
 };
 
@@ -1860,7 +1860,7 @@ interface IDBIndex {
 }
 
 declare var IDBIndex: {
-    readonly prototype: IDBIndex;
+    prototype: IDBIndex;
     new(): IDBIndex;
 };
 
@@ -1889,7 +1889,7 @@ interface IDBKeyRange {
 }
 
 declare var IDBKeyRange: {
-    readonly prototype: IDBKeyRange;
+    prototype: IDBKeyRange;
     new(): IDBKeyRange;
     /**
      * Returns a new IDBKeyRange spanning from lower to upper. If lowerOpen is true, lower is not included in the range. If upperOpen is true, upper is not included in the range.
@@ -2021,7 +2021,7 @@ interface IDBObjectStore {
 }
 
 declare var IDBObjectStore: {
-    readonly prototype: IDBObjectStore;
+    prototype: IDBObjectStore;
     new(): IDBObjectStore;
 };
 
@@ -2041,7 +2041,7 @@ interface IDBOpenDBRequest extends IDBRequest<IDBDatabase> {
 }
 
 declare var IDBOpenDBRequest: {
-    readonly prototype: IDBOpenDBRequest;
+    prototype: IDBOpenDBRequest;
     new(): IDBOpenDBRequest;
 };
 
@@ -2081,7 +2081,7 @@ interface IDBRequest<T = any> extends EventTarget {
 }
 
 declare var IDBRequest: {
-    readonly prototype: IDBRequest;
+    prototype: IDBRequest;
     new(): IDBRequest;
 };
 
@@ -2127,7 +2127,7 @@ interface IDBTransaction extends EventTarget {
 }
 
 declare var IDBTransaction: {
-    readonly prototype: IDBTransaction;
+    prototype: IDBTransaction;
     new(): IDBTransaction;
 };
 
@@ -2138,7 +2138,7 @@ interface IDBVersionChangeEvent extends Event {
 }
 
 declare var IDBVersionChangeEvent: {
-    readonly prototype: IDBVersionChangeEvent;
+    prototype: IDBVersionChangeEvent;
     new(type: string, eventInitDict?: IDBVersionChangeEventInit): IDBVersionChangeEvent;
 };
 
@@ -2158,7 +2158,7 @@ interface ImageBitmap {
 }
 
 declare var ImageBitmap: {
-    readonly prototype: ImageBitmap;
+    prototype: ImageBitmap;
     new(): ImageBitmap;
 };
 
@@ -2170,7 +2170,7 @@ interface ImageBitmapRenderingContext {
 }
 
 declare var ImageBitmapRenderingContext: {
-    readonly prototype: ImageBitmapRenderingContext;
+    prototype: ImageBitmapRenderingContext;
     new(): ImageBitmapRenderingContext;
 };
 
@@ -2191,7 +2191,7 @@ interface ImageData {
 }
 
 declare var ImageData: {
-    readonly prototype: ImageData;
+    prototype: ImageData;
     new(sw: number, sh: number, settings?: ImageDataSettings): ImageData;
     new(data: Uint8ClampedArray, sw: number, sh?: number, settings?: ImageDataSettings): ImageData;
 };
@@ -2206,7 +2206,7 @@ interface MediaCapabilities {
 }
 
 declare var MediaCapabilities: {
-    readonly prototype: MediaCapabilities;
+    prototype: MediaCapabilities;
     new(): MediaCapabilities;
 };
 
@@ -2223,7 +2223,7 @@ interface MessageChannel {
 }
 
 declare var MessageChannel: {
-    readonly prototype: MessageChannel;
+    prototype: MessageChannel;
     new(): MessageChannel;
 };
 
@@ -2254,7 +2254,7 @@ interface MessageEvent<T = any> extends Event {
 }
 
 declare var MessageEvent: {
-    readonly prototype: MessageEvent;
+    prototype: MessageEvent;
     new<T>(type: string, eventInitDict?: MessageEventInit<T>): MessageEvent<T>;
 };
 
@@ -2289,7 +2289,7 @@ interface MessagePort extends EventTarget {
 }
 
 declare var MessagePort: {
-    readonly prototype: MessagePort;
+    prototype: MessagePort;
     new(): MessagePort;
 };
 
@@ -2333,7 +2333,7 @@ interface NetworkInformation extends EventTarget {
 }
 
 declare var NetworkInformation: {
-    readonly prototype: NetworkInformation;
+    prototype: NetworkInformation;
     new(): NetworkInformation;
 };
 
@@ -2365,7 +2365,7 @@ interface Notification extends EventTarget {
 }
 
 declare var Notification: {
-    readonly prototype: Notification;
+    prototype: Notification;
     new(title: string, options?: NotificationOptions): Notification;
     readonly permission: NotificationPermission;
 };
@@ -2377,7 +2377,7 @@ interface NotificationEvent extends ExtendableEvent {
 }
 
 declare var NotificationEvent: {
-    readonly prototype: NotificationEvent;
+    prototype: NotificationEvent;
     new(type: string, eventInitDict: NotificationEventInit): NotificationEvent;
 };
 
@@ -2435,7 +2435,7 @@ interface Path2D extends CanvasPath {
 }
 
 declare var Path2D: {
-    readonly prototype: Path2D;
+    prototype: Path2D;
     new(path?: Path2D | string): Path2D;
 };
 
@@ -2465,7 +2465,7 @@ interface Performance extends EventTarget {
 }
 
 declare var Performance: {
-    readonly prototype: Performance;
+    prototype: Performance;
     new(): Performance;
 };
 
@@ -2479,7 +2479,7 @@ interface PerformanceEntry {
 }
 
 declare var PerformanceEntry: {
-    readonly prototype: PerformanceEntry;
+    prototype: PerformanceEntry;
     new(): PerformanceEntry;
 };
 
@@ -2489,7 +2489,7 @@ interface PerformanceMark extends PerformanceEntry {
 }
 
 declare var PerformanceMark: {
-    readonly prototype: PerformanceMark;
+    prototype: PerformanceMark;
     new(markName: string, markOptions?: PerformanceMarkOptions): PerformanceMark;
 };
 
@@ -2499,7 +2499,7 @@ interface PerformanceMeasure extends PerformanceEntry {
 }
 
 declare var PerformanceMeasure: {
-    readonly prototype: PerformanceMeasure;
+    prototype: PerformanceMeasure;
     new(): PerformanceMeasure;
 };
 
@@ -2510,7 +2510,7 @@ interface PerformanceObserver {
 }
 
 declare var PerformanceObserver: {
-    readonly prototype: PerformanceObserver;
+    prototype: PerformanceObserver;
     new(callback: PerformanceObserverCallback): PerformanceObserver;
     readonly supportedEntryTypes: ReadonlyArray<string>;
 };
@@ -2522,7 +2522,7 @@ interface PerformanceObserverEntryList {
 }
 
 declare var PerformanceObserverEntryList: {
-    readonly prototype: PerformanceObserverEntryList;
+    prototype: PerformanceObserverEntryList;
     new(): PerformanceObserverEntryList;
 };
 
@@ -2550,7 +2550,7 @@ interface PerformanceResourceTiming extends PerformanceEntry {
 }
 
 declare var PerformanceResourceTiming: {
-    readonly prototype: PerformanceResourceTiming;
+    prototype: PerformanceResourceTiming;
     new(): PerformanceResourceTiming;
 };
 
@@ -2562,7 +2562,7 @@ interface PerformanceServerTiming {
 }
 
 declare var PerformanceServerTiming: {
-    readonly prototype: PerformanceServerTiming;
+    prototype: PerformanceServerTiming;
     new(): PerformanceServerTiming;
 };
 
@@ -2580,7 +2580,7 @@ interface PermissionStatus extends EventTarget {
 }
 
 declare var PermissionStatus: {
-    readonly prototype: PermissionStatus;
+    prototype: PermissionStatus;
     new(): PermissionStatus;
 };
 
@@ -2589,7 +2589,7 @@ interface Permissions {
 }
 
 declare var Permissions: {
-    readonly prototype: Permissions;
+    prototype: Permissions;
     new(): Permissions;
 };
 
@@ -2602,7 +2602,7 @@ interface ProgressEvent<T extends EventTarget = EventTarget> extends Event {
 }
 
 declare var ProgressEvent: {
-    readonly prototype: ProgressEvent;
+    prototype: ProgressEvent;
     new(type: string, eventInitDict?: ProgressEventInit): ProgressEvent;
 };
 
@@ -2612,7 +2612,7 @@ interface PromiseRejectionEvent extends Event {
 }
 
 declare var PromiseRejectionEvent: {
-    readonly prototype: PromiseRejectionEvent;
+    prototype: PromiseRejectionEvent;
     new(type: string, eventInitDict: PromiseRejectionEventInit): PromiseRejectionEvent;
 };
 
@@ -2622,7 +2622,7 @@ interface PushEvent extends ExtendableEvent {
 }
 
 declare var PushEvent: {
-    readonly prototype: PushEvent;
+    prototype: PushEvent;
     new(type: string, eventInitDict?: PushEventInit): PushEvent;
 };
 
@@ -2634,7 +2634,7 @@ interface PushManager {
 }
 
 declare var PushManager: {
-    readonly prototype: PushManager;
+    prototype: PushManager;
     new(): PushManager;
     readonly supportedContentEncodings: ReadonlyArray<string>;
 };
@@ -2648,7 +2648,7 @@ interface PushMessageData {
 }
 
 declare var PushMessageData: {
-    readonly prototype: PushMessageData;
+    prototype: PushMessageData;
     new(): PushMessageData;
 };
 
@@ -2662,7 +2662,7 @@ interface PushSubscription {
 }
 
 declare var PushSubscription: {
-    readonly prototype: PushSubscription;
+    prototype: PushSubscription;
     new(): PushSubscription;
 };
 
@@ -2671,7 +2671,7 @@ interface PushSubscriptionOptions {
 }
 
 declare var PushSubscriptionOptions: {
-    readonly prototype: PushSubscriptionOptions;
+    prototype: PushSubscriptionOptions;
     new(): PushSubscriptionOptions;
 };
 
@@ -2687,7 +2687,7 @@ interface ReadableStream<R = any> {
 }
 
 declare var ReadableStream: {
-    readonly prototype: ReadableStream;
+    prototype: ReadableStream;
     new<R = any>(underlyingSource?: UnderlyingSource<R>, strategy?: QueuingStrategy<R>): ReadableStream<R>;
 };
 
@@ -2699,7 +2699,7 @@ interface ReadableStreamDefaultController<R = any> {
 }
 
 declare var ReadableStreamDefaultController: {
-    readonly prototype: ReadableStreamDefaultController;
+    prototype: ReadableStreamDefaultController;
     new(): ReadableStreamDefaultController;
 };
 
@@ -2709,7 +2709,7 @@ interface ReadableStreamDefaultReader<R = any> extends ReadableStreamGenericRead
 }
 
 declare var ReadableStreamDefaultReader: {
-    readonly prototype: ReadableStreamDefaultReader;
+    prototype: ReadableStreamDefaultReader;
     new<R = any>(stream: ReadableStream<R>): ReadableStreamDefaultReader<R>;
 };
 
@@ -2776,7 +2776,7 @@ interface Request extends Body {
 }
 
 declare var Request: {
-    readonly prototype: Request;
+    prototype: Request;
     new(input: RequestInfo, init?: RequestInit): Request;
 };
 
@@ -2793,7 +2793,7 @@ interface Response extends Body {
 }
 
 declare var Response: {
-    readonly prototype: Response;
+    prototype: Response;
     new(body?: BodyInit | null, init?: ResponseInit): Response;
     error(): Response;
     redirect(url: string | URL, status?: number): Response;
@@ -2816,7 +2816,7 @@ interface SecurityPolicyViolationEvent extends Event {
 }
 
 declare var SecurityPolicyViolationEvent: {
-    readonly prototype: SecurityPolicyViolationEvent;
+    prototype: SecurityPolicyViolationEvent;
     new(type: string, eventInitDict?: SecurityPolicyViolationEventInit): SecurityPolicyViolationEvent;
 };
 
@@ -2838,7 +2838,7 @@ interface ServiceWorker extends EventTarget, AbstractWorker {
 }
 
 declare var ServiceWorker: {
-    readonly prototype: ServiceWorker;
+    prototype: ServiceWorker;
     new(): ServiceWorker;
 };
 
@@ -2866,7 +2866,7 @@ interface ServiceWorkerContainer extends EventTarget {
 }
 
 declare var ServiceWorkerContainer: {
-    readonly prototype: ServiceWorkerContainer;
+    prototype: ServiceWorkerContainer;
     new(): ServiceWorkerContainer;
 };
 
@@ -2901,7 +2901,7 @@ interface ServiceWorkerGlobalScope extends WorkerGlobalScope {
 }
 
 declare var ServiceWorkerGlobalScope: {
-    readonly prototype: ServiceWorkerGlobalScope;
+    prototype: ServiceWorkerGlobalScope;
     new(): ServiceWorkerGlobalScope;
 };
 
@@ -2929,7 +2929,7 @@ interface ServiceWorkerRegistration extends EventTarget {
 }
 
 declare var ServiceWorkerRegistration: {
-    readonly prototype: ServiceWorkerRegistration;
+    prototype: ServiceWorkerRegistration;
     new(): ServiceWorkerRegistration;
 };
 
@@ -2954,7 +2954,7 @@ interface SharedWorkerGlobalScope extends WorkerGlobalScope {
 }
 
 declare var SharedWorkerGlobalScope: {
-    readonly prototype: SharedWorkerGlobalScope;
+    prototype: SharedWorkerGlobalScope;
     new(): SharedWorkerGlobalScope;
 };
 
@@ -2964,7 +2964,7 @@ interface StorageManager {
 }
 
 declare var StorageManager: {
-    readonly prototype: StorageManager;
+    prototype: StorageManager;
     new(): StorageManager;
 };
 
@@ -2989,7 +2989,7 @@ interface SubtleCrypto {
 }
 
 declare var SubtleCrypto: {
-    readonly prototype: SubtleCrypto;
+    prototype: SubtleCrypto;
     new(): SubtleCrypto;
 };
 
@@ -3012,7 +3012,7 @@ interface TextDecoder extends TextDecoderCommon {
 }
 
 declare var TextDecoder: {
-    readonly prototype: TextDecoder;
+    prototype: TextDecoder;
     new(label?: string, options?: TextDecoderOptions): TextDecoder;
 };
 
@@ -3037,7 +3037,7 @@ interface TextDecoderStream extends GenericTransformStream, TextDecoderCommon {
 }
 
 declare var TextDecoderStream: {
-    readonly prototype: TextDecoderStream;
+    prototype: TextDecoderStream;
     new(label?: string, options?: TextDecoderOptions): TextDecoderStream;
 };
 
@@ -3054,7 +3054,7 @@ interface TextEncoder extends TextEncoderCommon {
 }
 
 declare var TextEncoder: {
-    readonly prototype: TextEncoder;
+    prototype: TextEncoder;
     new(): TextEncoder;
 };
 
@@ -3071,7 +3071,7 @@ interface TextEncoderStream extends GenericTransformStream, TextEncoderCommon {
 }
 
 declare var TextEncoderStream: {
-    readonly prototype: TextEncoderStream;
+    prototype: TextEncoderStream;
     new(): TextEncoderStream;
 };
 
@@ -3108,7 +3108,7 @@ interface TextMetrics {
 }
 
 declare var TextMetrics: {
-    readonly prototype: TextMetrics;
+    prototype: TextMetrics;
     new(): TextMetrics;
 };
 
@@ -3118,7 +3118,7 @@ interface TransformStream<I = any, O = any> {
 }
 
 declare var TransformStream: {
-    readonly prototype: TransformStream;
+    prototype: TransformStream;
     new<I = any, O = any>(transformer?: Transformer<I, O>, writableStrategy?: QueuingStrategy<I>, readableStrategy?: QueuingStrategy<O>): TransformStream<I, O>;
 };
 
@@ -3130,7 +3130,7 @@ interface TransformStreamDefaultController<O = any> {
 }
 
 declare var TransformStreamDefaultController: {
-    readonly prototype: TransformStreamDefaultController;
+    prototype: TransformStreamDefaultController;
     new(): TransformStreamDefaultController;
 };
 
@@ -3153,7 +3153,7 @@ interface URL {
 }
 
 declare var URL: {
-    readonly prototype: URL;
+    prototype: URL;
     new(url: string | URL, base?: string | URL): URL;
     createObjectURL(object: any): string;
     revokeObjectURL(url: string): void;
@@ -3193,7 +3193,7 @@ interface URLSearchParams {
 }
 
 declare var URLSearchParams: {
-    readonly prototype: URLSearchParams;
+    prototype: URLSearchParams;
     new(init?: string[][] | Record<string, string> | string | URLSearchParams): URLSearchParams;
     toString(): string;
 };
@@ -3337,7 +3337,7 @@ interface WebGL2RenderingContext extends WebGL2RenderingContextBase, WebGL2Rende
 }
 
 declare var WebGL2RenderingContext: {
-    readonly prototype: WebGL2RenderingContext;
+    prototype: WebGL2RenderingContext;
     new(): WebGL2RenderingContext;
     readonly ACTIVE_UNIFORM_BLOCKS: GLenum;
     readonly ALREADY_SIGNALED: GLenum;
@@ -4305,7 +4305,7 @@ interface WebGLActiveInfo {
 }
 
 declare var WebGLActiveInfo: {
-    readonly prototype: WebGLActiveInfo;
+    prototype: WebGLActiveInfo;
     new(): WebGLActiveInfo;
 };
 
@@ -4314,7 +4314,7 @@ interface WebGLBuffer {
 }
 
 declare var WebGLBuffer: {
-    readonly prototype: WebGLBuffer;
+    prototype: WebGLBuffer;
     new(): WebGLBuffer;
 };
 
@@ -4324,7 +4324,7 @@ interface WebGLContextEvent extends Event {
 }
 
 declare var WebGLContextEvent: {
-    readonly prototype: WebGLContextEvent;
+    prototype: WebGLContextEvent;
     new(type: string, eventInit?: WebGLContextEventInit): WebGLContextEvent;
 };
 
@@ -4333,7 +4333,7 @@ interface WebGLFramebuffer {
 }
 
 declare var WebGLFramebuffer: {
-    readonly prototype: WebGLFramebuffer;
+    prototype: WebGLFramebuffer;
     new(): WebGLFramebuffer;
 };
 
@@ -4342,7 +4342,7 @@ interface WebGLProgram {
 }
 
 declare var WebGLProgram: {
-    readonly prototype: WebGLProgram;
+    prototype: WebGLProgram;
     new(): WebGLProgram;
 };
 
@@ -4350,7 +4350,7 @@ interface WebGLQuery {
 }
 
 declare var WebGLQuery: {
-    readonly prototype: WebGLQuery;
+    prototype: WebGLQuery;
     new(): WebGLQuery;
 };
 
@@ -4359,7 +4359,7 @@ interface WebGLRenderbuffer {
 }
 
 declare var WebGLRenderbuffer: {
-    readonly prototype: WebGLRenderbuffer;
+    prototype: WebGLRenderbuffer;
     new(): WebGLRenderbuffer;
 };
 
@@ -4368,7 +4368,7 @@ interface WebGLRenderingContext extends WebGLRenderingContextBase, WebGLRenderin
 }
 
 declare var WebGLRenderingContext: {
-    readonly prototype: WebGLRenderingContext;
+    prototype: WebGLRenderingContext;
     new(): WebGLRenderingContext;
     readonly ACTIVE_ATTRIBUTES: GLenum;
     readonly ACTIVE_TEXTURE: GLenum;
@@ -5145,7 +5145,7 @@ interface WebGLSampler {
 }
 
 declare var WebGLSampler: {
-    readonly prototype: WebGLSampler;
+    prototype: WebGLSampler;
     new(): WebGLSampler;
 };
 
@@ -5154,7 +5154,7 @@ interface WebGLShader {
 }
 
 declare var WebGLShader: {
-    readonly prototype: WebGLShader;
+    prototype: WebGLShader;
     new(): WebGLShader;
 };
 
@@ -5166,7 +5166,7 @@ interface WebGLShaderPrecisionFormat {
 }
 
 declare var WebGLShaderPrecisionFormat: {
-    readonly prototype: WebGLShaderPrecisionFormat;
+    prototype: WebGLShaderPrecisionFormat;
     new(): WebGLShaderPrecisionFormat;
 };
 
@@ -5174,7 +5174,7 @@ interface WebGLSync {
 }
 
 declare var WebGLSync: {
-    readonly prototype: WebGLSync;
+    prototype: WebGLSync;
     new(): WebGLSync;
 };
 
@@ -5183,7 +5183,7 @@ interface WebGLTexture {
 }
 
 declare var WebGLTexture: {
-    readonly prototype: WebGLTexture;
+    prototype: WebGLTexture;
     new(): WebGLTexture;
 };
 
@@ -5191,7 +5191,7 @@ interface WebGLTransformFeedback {
 }
 
 declare var WebGLTransformFeedback: {
-    readonly prototype: WebGLTransformFeedback;
+    prototype: WebGLTransformFeedback;
     new(): WebGLTransformFeedback;
 };
 
@@ -5200,7 +5200,7 @@ interface WebGLUniformLocation {
 }
 
 declare var WebGLUniformLocation: {
-    readonly prototype: WebGLUniformLocation;
+    prototype: WebGLUniformLocation;
     new(): WebGLUniformLocation;
 };
 
@@ -5208,7 +5208,7 @@ interface WebGLVertexArrayObject {
 }
 
 declare var WebGLVertexArrayObject: {
-    readonly prototype: WebGLVertexArrayObject;
+    prototype: WebGLVertexArrayObject;
     new(): WebGLVertexArrayObject;
 };
 
@@ -5275,7 +5275,7 @@ interface WebSocket extends EventTarget {
 }
 
 declare var WebSocket: {
-    readonly prototype: WebSocket;
+    prototype: WebSocket;
     new(url: string | URL, protocols?: string | string[]): WebSocket;
     readonly CLOSED: number;
     readonly CLOSING: number;
@@ -5292,7 +5292,7 @@ interface WindowClient extends Client {
 }
 
 declare var WindowClient: {
-    readonly prototype: WindowClient;
+    prototype: WindowClient;
     new(): WindowClient;
 };
 
@@ -5341,7 +5341,7 @@ interface Worker extends EventTarget, AbstractWorker {
 }
 
 declare var Worker: {
-    readonly prototype: Worker;
+    prototype: Worker;
     new(scriptURL: string | URL, options?: WorkerOptions): Worker;
 };
 
@@ -5385,7 +5385,7 @@ interface WorkerGlobalScope extends EventTarget, FontFaceSource, WindowOrWorkerG
 }
 
 declare var WorkerGlobalScope: {
-    readonly prototype: WorkerGlobalScope;
+    prototype: WorkerGlobalScope;
     new(): WorkerGlobalScope;
 };
 
@@ -5404,7 +5404,7 @@ interface WorkerLocation {
 }
 
 declare var WorkerLocation: {
-    readonly prototype: WorkerLocation;
+    prototype: WorkerLocation;
     new(): WorkerLocation;
 };
 
@@ -5413,7 +5413,7 @@ interface WorkerNavigator extends NavigatorConcurrentHardware, NavigatorID, Navi
 }
 
 declare var WorkerNavigator: {
-    readonly prototype: WorkerNavigator;
+    prototype: WorkerNavigator;
     new(): WorkerNavigator;
 };
 
@@ -5426,7 +5426,7 @@ interface WritableStream<W = any> {
 }
 
 declare var WritableStream: {
-    readonly prototype: WritableStream;
+    prototype: WritableStream;
     new<W = any>(underlyingSink?: UnderlyingSink<W>, strategy?: QueuingStrategy<W>): WritableStream<W>;
 };
 
@@ -5436,7 +5436,7 @@ interface WritableStreamDefaultController {
 }
 
 declare var WritableStreamDefaultController: {
-    readonly prototype: WritableStreamDefaultController;
+    prototype: WritableStreamDefaultController;
     new(): WritableStreamDefaultController;
 };
 
@@ -5452,7 +5452,7 @@ interface WritableStreamDefaultWriter<W = any> {
 }
 
 declare var WritableStreamDefaultWriter: {
-    readonly prototype: WritableStreamDefaultWriter;
+    prototype: WritableStreamDefaultWriter;
     new<W = any>(stream: WritableStream<W>): WritableStreamDefaultWriter<W>;
 };
 
@@ -5557,7 +5557,7 @@ interface XMLHttpRequest extends XMLHttpRequestEventTarget {
 }
 
 declare var XMLHttpRequest: {
-    readonly prototype: XMLHttpRequest;
+    prototype: XMLHttpRequest;
     new(): XMLHttpRequest;
     readonly DONE: number;
     readonly HEADERS_RECEIVED: number;
@@ -5591,7 +5591,7 @@ interface XMLHttpRequestEventTarget extends EventTarget {
 }
 
 declare var XMLHttpRequestEventTarget: {
-    readonly prototype: XMLHttpRequestEventTarget;
+    prototype: XMLHttpRequestEventTarget;
     new(): XMLHttpRequestEventTarget;
 };
 
@@ -5603,7 +5603,7 @@ interface XMLHttpRequestUpload extends XMLHttpRequestEventTarget {
 }
 
 declare var XMLHttpRequestUpload: {
-    readonly prototype: XMLHttpRequestUpload;
+    prototype: XMLHttpRequestUpload;
     new(): XMLHttpRequestUpload;
 };
 
@@ -5637,7 +5637,7 @@ declare namespace WebAssembly {
     }
 
     var CompileError: {
-        readonly prototype: CompileError;
+        prototype: CompileError;
         new(): CompileError;
     };
 
@@ -5647,7 +5647,7 @@ declare namespace WebAssembly {
     }
 
     var Global: {
-        readonly prototype: Global;
+        prototype: Global;
         new(descriptor: GlobalDescriptor, v?: any): Global;
     };
 
@@ -5656,7 +5656,7 @@ declare namespace WebAssembly {
     }
 
     var Instance: {
-        readonly prototype: Instance;
+        prototype: Instance;
         new(module: Module, importObject?: Imports): Instance;
     };
 
@@ -5664,7 +5664,7 @@ declare namespace WebAssembly {
     }
 
     var LinkError: {
-        readonly prototype: LinkError;
+        prototype: LinkError;
         new(): LinkError;
     };
 
@@ -5674,7 +5674,7 @@ declare namespace WebAssembly {
     }
 
     var Memory: {
-        readonly prototype: Memory;
+        prototype: Memory;
         new(descriptor: MemoryDescriptor): Memory;
     };
 
@@ -5682,7 +5682,7 @@ declare namespace WebAssembly {
     }
 
     var Module: {
-        readonly prototype: Module;
+        prototype: Module;
         new(bytes: BufferSource): Module;
         customSections(moduleObject: Module, sectionName: string): ArrayBuffer[];
         exports(moduleObject: Module): ModuleExportDescriptor[];
@@ -5693,7 +5693,7 @@ declare namespace WebAssembly {
     }
 
     var RuntimeError: {
-        readonly prototype: RuntimeError;
+        prototype: RuntimeError;
         new(): RuntimeError;
     };
 
@@ -5705,7 +5705,7 @@ declare namespace WebAssembly {
     }
 
     var Table: {
-        readonly prototype: Table;
+        prototype: Table;
         new(descriptor: TableDescriptor, value?: any): Table;
     };
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint --max-warnings 0 src",
     "test": "npm run lint && npm run build && node ./lib/test.js && node ./unittests/index.js",
     "changelog": "tsc && node ./lib/changelog.js",
-    "version": "tsc && node ./lib/version.js"
+    "version": "npm i && tsc && node ./lib/version.js"
   },
   "author": {
     "name": "Kagami Sascha Rosylight",

--- a/src/build/emitter.ts
+++ b/src/build/emitter.ts
@@ -1104,7 +1104,8 @@ export function emitWebIdl(
     printer.printLine(`${prefix}var ${i.name}: {`);
     printer.increaseIndent();
 
-    printer.printLine(`readonly prototype: ${i.name};`);
+    // TODO: 'strict emit' with readonly added back?
+    printer.printLine(`prototype: ${i.name};`);
     emitConstructorSignature(i);
     emitConstants(i);
     if (iNameToConstParents[i.name]?.length) {

--- a/src/build/emitter.ts
+++ b/src/build/emitter.ts
@@ -1104,7 +1104,9 @@ export function emitWebIdl(
     printer.printLine(`${prefix}var ${i.name}: {`);
     printer.increaseIndent();
 
-    // TODO: 'strict emit' with readonly added back?
+    // TODO: To be more accurate, this should be `readonly prototype`
+    // however, TypeScript's ability to keep track of readonly-ness can
+    // sometimes fail in un-expected ways, making this not backwards compatible.
     printer.printLine(`prototype: ${i.name};`);
     emitConstructorSignature(i);
     emitConstants(i);


### PR DESCRIPTION
Basically, when someone sends a type through enough transformation - the `readonly` can get lost. This can mean when that the two versions of the same thing to _not_ be the same, even though they refer to the same type. It's _probably_ intentional somewhere in the compiler that this happens because `readonly` support is real real complex in the compiler.