### PR TITLE
Add back ClientRect

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3496,6 +3496,10 @@ interface ChildNode {
     replaceWith(...nodes: (Node | string)[]): void;
 }
 
+/** @deprecated */
+interface ClientRect extends DOMRect {
+}
+
 interface Clipboard extends EventTarget {
     read(): Promise<ClipboardItems>;
     readText(): Promise<string>;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -557,6 +557,14 @@
                     }
                 }
             },
+            // This is used in many DT libraries, via ckeditor
+            "ClientRect": {
+                "name": "ClientRect",
+                "exposed": "Window",
+                "deprecated": true,
+                "extends": "DOMRect",
+                "noInterfaceObject": true
+            },
             /*
               Keeping EventListener and EventListenerObject isn't the most elegant way to handle
               the event listeners, but we need to keep the EventListener as an extendable interface


### PR DESCRIPTION
( I can't comment in the JSON because that's in  #110 )

Roughly, this is used in ckeditor which triggers a gazillion fails across DT 